### PR TITLE
fix: Updates aws provider to at least 3.0.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = ">= 2.67, < 4.0"
+    aws = ">= 3.0, < 4.0"
   }
 }


### PR DESCRIPTION
## Description
Bumps the aws provider version due to a rename of cloudfront distribution property.

## Motivation and Context
See #3 

## Breaking Changes
Anyone using this module with < 3.0 should not be able to plan anyways.

## How Has This Been Tested?
When attempting to use the module, I stumbled upon this.  See #3 for a test file you can dump into a temp directory and run terraform init and plan.  When using the file as is, the error can be observed.  When the provider version is updated to 3.0, no error is provided.
