### PR TITLE
feat: Adds outputs for origin access identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ module "cdn" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | >= 2.67, < 4.0 |
+| aws | >= 3.0, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.67, < 4.0 |
+| aws | >= 3.0, < 4.0 |
 
 ## Inputs
 
@@ -144,6 +144,8 @@ module "cdn" {
 | this\_cloudfront\_distribution\_last\_modified\_time | The date and time the distribution was last modified. |
 | this\_cloudfront\_distribution\_status | The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system. |
 | this\_cloudfront\_distribution\_trusted\_signers | List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs |
+| this\_cloudfront\_origin\_access\_identity\_iam\_arns | The IAM arns of the origin access identities created |
+| this\_cloudfront\_origin\_access\_identity\_ids | The IDS of the origin access identities created |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ module "cdn" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6, < 0.14 |
-| aws | >= 3.0, < 4.0 |
+| terraform | >= 0.12.6 |
+| aws | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0, < 4.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -4,6 +4,7 @@ Configuration in this directory creates CloudFront distribution which demos such
 - access logging
 - origins and origin groups
 - caching behaviours
+- Origin Access Identities (with S3 bucket policy)
 - Lambda@Edge
 - ACM certificate
 - Route53 record
@@ -25,8 +26,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6, < 0.14 |
-| aws | >= 2.67, < 4.0 |
+| terraform | >= 0.12.6 |
+| aws | >= 3.0 |
 | null | ~> 2 |
 | random | ~> 2 |
 
@@ -34,7 +35,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.67, < 4.0 |
+| aws | >= 3.0 |
 | null | ~> 2 |
 | random | ~> 2 |
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -246,6 +246,26 @@ module "records" {
   ]
 }
 
+###########################
+# Origin Access Identities
+###########################
+data "aws_iam_policy_document" "s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${module.s3_one.this_s3_bucket_arn}/uploads/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [for k, v in module.cloudfront.this_cloudfront_origin_access_identity_iam_arns : v]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = module.s3_one.this_s3_bucket_id
+  policy = data.aws_iam_policy_document.s3_policy.json
+}
+
 ########
 # Extra
 ########

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.67, < 4.0"
+    aws    = ">= 3.0"
     random = "~> 2"
     null   = "~> 2"
   }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,9 @@
+locals {
+  create_origin_access_identity = var.create_origin_access_identity && length(keys(var.origin_access_identities)) > 0
+}
+
 resource "aws_cloudfront_origin_access_identity" "this" {
-  for_each = var.create_origin_access_identity && length(keys(var.origin_access_identities)) > 0 ? var.origin_access_identities : {}
+  for_each = local.create_origin_access_identity ? var.origin_access_identities : {}
 
   comment = each.value
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,3 +47,13 @@ output "this_cloudfront_distribution_hosted_zone_id" {
   description = "The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to."
   value       = element(concat(aws_cloudfront_distribution.this.*.hosted_zone_id, list("")), 0)
 }
+
+output "this_cloudfront_origin_access_identity_ids" {
+  description = "The IDS of the origin access identities created"
+  value       = local.create_origin_access_identity ? { for k, v in var.origin_access_identities : k => aws_cloudfront_origin_access_identity.this[k].id } : {}
+}
+
+output "this_cloudfront_origin_access_identity_iam_arns" {
+  description = "The IAM arns of the origin access identities created"
+  value       = local.create_origin_access_identity ? { for k, v in var.origin_access_identities : k => aws_cloudfront_origin_access_identity.this[k].iam_arn } : {}
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 3.0, < 4.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
## Description

Adds outputs for origin access identities.

## Motivation and Context

We desired to use the origin access identities in our s3 bucket policy

## Breaking Changes

No

## How Has This Been Tested?

```
$ terraform -v
Terraform v0.12.29
+ provider.aws v3.11.0
+ provider.null v2.1.2
+ provider.random v2.3.0
```

We have deployed this in two environments successfully.  Here is a snippet:
```hcl
data "aws_s3_bucket" "upload-bucket" {
  bucket = "uploads.example.com"
}

module "cdn" {
  source = "../terraform-aws-cloudfront"
  // ....
}

data "aws_iam_policy_document" "s3_policy" {
  statement {
    actions   = ["s3:GetObject"]
    resources = ["${data.aws_s3_bucket.upload-bucket.arn}/uploads/*"]

    principals {
      type        = "AWS"
      identifiers = [for k, v in module.cdn.this_cloudfront_origin_access_identity_iam_arns : v]
    }
  }
}

resource "aws_s3_bucket_policy" "cdn-bucket-policy" {
  bucket = data.aws_s3_bucket.upload-bucket.id
  policy = data.aws_iam_policy_document.s3_policy.json
}

```
