### PR TITLE
refactor: change origin access identity output types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 terraform.tfstate
 *.tfstate*
 terraform.tfvars
+.terraform.lock.hcl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.43.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -20,6 +20,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ module "cdn" {
 | this\_cloudfront\_distribution\_last\_modified\_time | The date and time the distribution was last modified. |
 | this\_cloudfront\_distribution\_status | The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system. |
 | this\_cloudfront\_distribution\_trusted\_signers | List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs |
-| this\_cloudfront\_origin\_access\_identity\_iam\_arns | The IAM arns of the origin access identities created |
-| this\_cloudfront\_origin\_access\_identity\_ids | The IDS of the origin access identities created |
+| this\_cloudfront\_origin\_access\_identities | Map of origin access identities created |
+| this\_cloudfront\_origin\_access\_identity\_iam\_arns | List of IAM arns of the origin access identities created |
+| this\_cloudfront\_origin\_access\_identity\_ids | List of IDS of the origin access identities created |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -57,5 +57,8 @@ No input.
 | this\_cloudfront\_distribution\_last\_modified\_time | The date and time the distribution was last modified. |
 | this\_cloudfront\_distribution\_status | The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system. |
 | this\_cloudfront\_distribution\_trusted\_signers | List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs |
+| this\_cloudfront\_origin\_access\_identities | Map of origin access identities created |
+| this\_cloudfront\_origin\_access\_identity\_iam\_arns | List of IAM arns of the origin access identities created |
+| this\_cloudfront\_origin\_access\_identity\_ids | List of IDS of the origin access identities created |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -256,7 +256,7 @@ data "aws_iam_policy_document" "s3_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [for k, v in module.cloudfront.this_cloudfront_origin_access_identity_iam_arns : v]
+      identifiers = module.cloudfront.this_cloudfront_origin_access_identity_iam_arns
     }
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -252,7 +252,7 @@ module "records" {
 data "aws_iam_policy_document" "s3_policy" {
   statement {
     actions   = ["s3:GetObject"]
-    resources = ["${module.s3_one.this_s3_bucket_arn}/uploads/*"]
+    resources = ["${module.s3_one.this_s3_bucket_arn}/static/*"]
 
     principals {
       type        = "AWS"

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -47,3 +47,18 @@ output "this_cloudfront_distribution_hosted_zone_id" {
   description = "The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to."
   value       = module.cloudfront.this_cloudfront_distribution_hosted_zone_id
 }
+
+output "this_cloudfront_origin_access_identities" {
+  description = "The origin access identities created"
+  value       = module.cloudfront.this_cloudfront_origin_access_identities
+}
+
+output "this_cloudfront_origin_access_identity_ids" {
+  description = "The IDS of the origin access identities created"
+  value       = module.cloudfront.this_cloudfront_origin_access_identity_ids
+}
+
+output "this_cloudfront_origin_access_identity_iam_arns" {
+  description = "The IAM arns of the origin access identities created"
+  value       = module.cloudfront.this_cloudfront_origin_access_identity_iam_arns
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,12 +48,17 @@ output "this_cloudfront_distribution_hosted_zone_id" {
   value       = element(concat(aws_cloudfront_distribution.this.*.hosted_zone_id, list("")), 0)
 }
 
+output "this_cloudfront_origin_access_identities" {
+  description = "The origin access identities created"
+  value       = local.create_origin_access_identity ? { for k, v in aws_cloudfront_origin_access_identity.this : k => v } : {}
+}
+
 output "this_cloudfront_origin_access_identity_ids" {
   description = "The IDS of the origin access identities created"
-  value       = local.create_origin_access_identity ? { for k, v in var.origin_access_identities : k => aws_cloudfront_origin_access_identity.this[k].id } : {}
+  value       = local.create_origin_access_identity ? [for v in aws_cloudfront_origin_access_identity.this : v.id] : []
 }
 
 output "this_cloudfront_origin_access_identity_iam_arns" {
   description = "The IAM arns of the origin access identities created"
-  value       = local.create_origin_access_identity ? { for k, v in var.origin_access_identities : k => aws_cloudfront_origin_access_identity.this[k].iam_arn } : {}
+  value       = local.create_origin_access_identity ? [for v in aws_cloudfront_origin_access_identity.this : v.iam_arn] : []
 }


### PR DESCRIPTION
## Description
Change the output types of `this_cloudfront_origin_access_identity_ids` and `this_cloudfront_origin_access_identity_iam_arns` to simple lists and add `this_cloudfront_origin_access_identities` as a map with the full origin access identities.

## Motivation and Context
Currently a map of origin access identities with ids and arns are available through `this_cloudfront_origin_access_identity_ids` and  `this_cloudfront_origin_access_identity_iam_arns`. The outputs are needed but the names give the wrong idea of the type to expect.

This PR will change the output types to lists, making it easier to use in S3 bucket policies etc. If you still need the full origin access identities or want to specify a single one they will be available through the new `this_cloudfront_origin_access_identities` output.

## Breaking Changes
This PR will break current implementations where the `this_cloudfront_origin_access_identity_ids` and `this_cloudfront_origin_access_identity_iam_arns` outputs are used.

Instead of 
```terraform
data "aws_iam_policy_document" "s3_policy" {
  statement {
    actions   = ["s3:GetObject"]
    resources = ["${data.aws_s3_bucket.upload-bucket.arn}/uploads/*"]

    principals {
      type        = "AWS"
      identifiers = [for k, v in module.cdn.this_cloudfront_origin_access_identity_iam_arns : v]
    }
  }
}
```

you will need to do
```terraform
data "aws_iam_policy_document" "s3_policy" {
  statement {
    actions   = ["s3:GetObject"]
    resources = ["${data.aws_s3_bucket.upload-bucket.arn}/uploads/*"]

    principals {
      type        = "AWS"
      identifiers = module.cdn.this_cloudfront_origin_access_identity_iam_arns
    }
  }
}
```

## How Has This Been Tested?
```
Terraform v0.13.4
+ provider registry.terraform.io/hashicorp/aws v3.13.0
+ provider registry.terraform.io/hashicorp/external v1.2.0
+ provider registry.terraform.io/hashicorp/local v1.4.0
+ provider registry.terraform.io/hashicorp/null v2.1.2
+ provider registry.terraform.io/hashicorp/random v2.3.1
```
