### PR TITLE
fix: Fixed viewer_certificate variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ module "cdn" {
 | price\_class | The price class for this distribution. One of PriceClass\_All, PriceClass\_200, PriceClass\_100 | `string` | `null` | no |
 | retain\_on\_delete | Disables the distribution instead of deleting it when destroying the resource through Terraform. If this is set, the distribution needs to be deleted manually afterwards. | `bool` | `false` | no |
 | tags | A map of tags to assign to the resource. | `map(string)` | `null` | no |
-| viewer\_certificate | The SSL configuration for this distribution | `any` | `null` | no |
+| viewer\_certificate | The SSL configuration for this distribution | `any` | <pre>{<br>  "cloudfront_default_certificate": true,<br>  "minimum_protocol_version": "TLSv1"<br>}</pre> | no |
 | wait\_for\_deployment | If enabled, the resource will wait for the distribution status to change from InProgress to Deployed. Setting this tofalse will skip the process. | `bool` | `true` | no |
 | web\_acl\_id | If you're using AWS WAF to filter CloudFront requests, the Id of the AWS WAF web ACL that is associated with the distribution. The WAF Web ACL must exist in the WAF Global (CloudFront) region and the credentials configuring this argument must have waf:GetWebACL permissions assigned. If using WAFv2, provide the ARN of the web ACL. | `string` | `null` | no |
 
@@ -144,9 +144,9 @@ module "cdn" {
 | this\_cloudfront\_distribution\_last\_modified\_time | The date and time the distribution was last modified. |
 | this\_cloudfront\_distribution\_status | The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system. |
 | this\_cloudfront\_distribution\_trusted\_signers | List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs |
-| this\_cloudfront\_origin\_access\_identities | Map of origin access identities created |
-| this\_cloudfront\_origin\_access\_identity\_iam\_arns | List of IAM arns of the origin access identities created |
-| this\_cloudfront\_origin\_access\_identity\_ids | List of IDS of the origin access identities created |
+| this\_cloudfront\_origin\_access\_identities | The origin access identities created |
+| this\_cloudfront\_origin\_access\_identity\_iam\_arns | The IAM arns of the origin access identities created |
+| this\_cloudfront\_origin\_access\_identity\_ids | The IDS of the origin access identities created |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -57,8 +57,8 @@ No input.
 | this\_cloudfront\_distribution\_last\_modified\_time | The date and time the distribution was last modified. |
 | this\_cloudfront\_distribution\_status | The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system. |
 | this\_cloudfront\_distribution\_trusted\_signers | List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs |
-| this\_cloudfront\_origin\_access\_identities | Map of origin access identities created |
-| this\_cloudfront\_origin\_access\_identity\_iam\_arns | List of IAM arns of the origin access identities created |
-| this\_cloudfront\_origin\_access\_identity\_ids | List of IDS of the origin access identities created |
+| this\_cloudfront\_origin\_access\_identities | The origin access identities created |
+| this\_cloudfront\_origin\_access\_identity\_iam\_arns | The IAM arns of the origin access identities created |
+| this\_cloudfront\_origin\_access\_identity\_ids | The IDS of the origin access identities created |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -177,20 +177,13 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
-  dynamic "viewer_certificate" {
-    for_each = var.viewer_certificate == null ? [{
-      cloudfront_default_certificate = true
-      minimum_protocol_version       = "TLSv1"
-    }] : [var.viewer_certificate]
+  viewer_certificate {
+    acm_certificate_arn            = lookup(var.viewer_certificate, "acm_certificate_arn", null)
+    cloudfront_default_certificate = lookup(var.viewer_certificate, "cloudfront_default_certificate", null)
+    iam_certificate_id             = lookup(var.viewer_certificate, "iam_certificate_id", null)
 
-    content {
-      acm_certificate_arn            = lookup(var.viewer_certificate, "acm_certificate_arn", null)
-      cloudfront_default_certificate = lookup(var.viewer_certificate, "cloudfront_default_certificate", null)
-      iam_certificate_id             = lookup(var.viewer_certificate, "iam_certificate_id", null)
-
-      minimum_protocol_version = lookup(var.viewer_certificate, "minimum_protocol_version", "TLSv1")
-      ssl_support_method       = lookup(var.viewer_certificate, "ssl_support_method", null)
-    }
+    minimum_protocol_version = lookup(var.viewer_certificate, "minimum_protocol_version", "TLSv1")
+    ssl_support_method       = lookup(var.viewer_certificate, "ssl_support_method", null)
   }
 
   dynamic "custom_error_response" {

--- a/variables.tf
+++ b/variables.tf
@@ -97,7 +97,7 @@ variable "origin_group" {
 variable "viewer_certificate" {
   description = "The SSL configuration for this distribution"
   type        = any
-  default     = {
+  default = {
     cloudfront_default_certificate = true
     minimum_protocol_version       = "TLSv1"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -97,7 +97,10 @@ variable "origin_group" {
 variable "viewer_certificate" {
   description = "The SSL configuration for this distribution"
   type        = any
-  default     = null
+  default     = {
+    cloudfront_default_certificate = true
+    minimum_protocol_version       = "TLSv1"
+  }
 }
 
 variable "geo_restriction" {


### PR DESCRIPTION
…cate inside the for_each loop

## Description
The for_each loop is not needed for viewer_certificate (1 block maximum can be used) and it generates errors when the viewer_certificate var is not used as input of the module.

## Motivation and Context
When we don't put the viewer_certificate block there are multiple errors on plan and apply like the error below: 

```
 on terraform-aws-cloudfront/main.tf line 187, in resource "aws_cloudfront_distribution" "this":
 187:       acm_certificate_arn            = lookup(var.viewer_certificate, "acm_certificate_arn", null)
    |----------------
    | var.viewer_certificate is null

Invalid value for "inputMap" parameter: argument must not be null.

```
 
## Breaking Changes
This fix should not break anything. 

## How Has This Been Tested?
This code has only been tested with a configuration that does not specify the viewer_certificate block 