### PR TITLE
fix: preserve ordering of cache behaviors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,19 +55,19 @@ module "cdn" {
       }
     }
   }
+  
+  default_cache_behavior = {
+    target_origin_id       = "something"
+    viewer_protocol_policy = "allow-all"
 
-  cache_behavior = {
-    default = {
-      target_origin_id       = "something"
-      viewer_protocol_policy = "allow-all"
-
-      allowed_methods = ["GET", "HEAD", "OPTIONS"]
-      cached_methods  = ["GET", "HEAD"]
-      compress        = true
-      query_string    = true
-    }
-
-    s3 = {
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods  = ["GET", "HEAD"]
+    compress        = true
+    query_string    = true
+  }
+  
+  ordered_cache_behavior = [
+    {
       path_pattern           = "/static/*"
       target_origin_id       = "s3_one"
       viewer_protocol_policy = "redirect-to-https"
@@ -77,7 +77,7 @@ module "cdn" {
       compress        = true
       query_string    = true
     }
-  }
+  ]
 
   viewer_certificate = {
     acm_certificate_arn = "arn:aws:acm:us-east-1:135367859851:certificate/1032b155-22da-4ae0-9f69-e206f825458b"
@@ -109,7 +109,8 @@ module "cdn" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aliases | Extra CNAMEs (alternate domain names), if any, for this distribution. | `list(string)` | `null` | no |
-| cache\_behavior | The map of cache behaviors for this distribution. Key `default` will be used as the default cache behavior, all other keys will be used as ordered list of cache behaviors. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0. | `any` | `null` | no |
+| default\_cache\_behavior | The default cache behavior for this distribution. | `any` | `null` | no |
+| ordered\_cache\_behavior | An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0. | `list(any)` | `null` | no |
 | comment | Any comments you want to include about the distribution. | `string` | `null` | no |
 | create\_distribution | Controls if CloudFront distribution should be created | `bool` | `true` | no |
 | create\_origin\_access\_identity | Controls if CloudFront origin access identity should be created | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -77,31 +77,31 @@ module "cloudfront" {
     }
   }
 
-  cache_behavior = {
-    default = {
-      target_origin_id       = "appsync"
-      viewer_protocol_policy = "allow-all"
+  default_cache_behavior = {
+    target_origin_id       = "appsync"
+    viewer_protocol_policy = "allow-all"
 
-      allowed_methods = ["GET", "HEAD", "OPTIONS"]
-      cached_methods  = ["GET", "HEAD"]
-      compress        = true
-      query_string    = true
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods  = ["GET", "HEAD"]
+    compress        = true
+    query_string    = true
 
-      lambda_function_association = {
+    lambda_function_association = {
 
-        # Valid keys: viewer-request, origin-request, viewer-response, origin-response
-        viewer-request = {
-          lambda_arn   = module.lambda_function.this_lambda_function_qualified_arn
-          include_body = true
-        }
+      # Valid keys: viewer-request, origin-request, viewer-response, origin-response
+      viewer-request = {
+        lambda_arn   = module.lambda_function.this_lambda_function_qualified_arn
+        include_body = true
+      }
 
-        origin-request = {
-          lambda_arn = module.lambda_function.this_lambda_function_qualified_arn
-        }
+      origin-request = {
+        lambda_arn = module.lambda_function.this_lambda_function_qualified_arn
       }
     }
+  }
 
-    s3 = {
+  ordered_cache_behavior = [
+    {
       path_pattern           = "/static/*"
       target_origin_id       = "s3_one"
       viewer_protocol_policy = "redirect-to-https"
@@ -111,7 +111,7 @@ module "cloudfront" {
       compress        = true
       query_string    = true
     }
-  }
+  ]
 
   viewer_certificate = {
     acm_certificate_arn = module.acm.this_acm_certificate_arn

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   dynamic "default_cache_behavior" {
-    for_each = [for k, v in var.cache_behavior : v if k == "default"]
+    for_each = [var.default_cache_behavior]
     iterator = i
 
     content {
@@ -134,7 +134,7 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   dynamic "ordered_cache_behavior" {
-    for_each = [for k, v in var.cache_behavior : v if k != "default"]
+    for_each = var.ordered_cache_behavior
     iterator = i
 
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -121,9 +121,14 @@ variable "custom_error_response" {
   default     = {}
 }
 
-variable "cache_behavior" {
-  description = "The map of cache behaviors for this distribution. Key `default` will be used as the default cache behavior, all other keys will be used as ordered list of cache behaviors. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0."
+variable "default_cache_behavior" {
+  description = "The default cache behavior for this distribution"
   type        = any
   default     = null
 }
 
+variable "ordered_cache_behavior" {
+  description = "An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0."
+  type        = list(any)
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -130,5 +130,5 @@ variable "default_cache_behavior" {
 variable "ordered_cache_behavior" {
   description = "An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0."
   type        = list(any)
-  default     = null
+  default     = []
 }


### PR DESCRIPTION


## Description
Separate variables for default and ordered cache behavior. 
Ordered cache behavior is now a list so that ordering is respected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It preserves the ordering of [cache behaviors](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#ordered_cache_behavior), so that the resulting precedence is correct.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes [issue 11](https://github.com/terraform-aws-modules/terraform-aws-cloudfront/issues/11).

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
Yes, because a variable has been removed (cache_behavior), and two new ones were added (default_cache_behavior and ordered_cache_behavior).

<!-- If so, please provide an explanation why it is necessary. -->
It is necessary because the root of the problem was in the variable definition itself, i.e. using a map to store an ordered list.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I adapted the _examples/complete_ and planned it.

<!--- Include details of your testing environment, and the tests you ran to -->
Additionally, we used our local fork with this change to create a new distribution with many cache behaviors. We did not encounter any issue, and the order of the cache behaviors was correctly preserved.

<!--- see how your change affects other areas of the code, etc. -->
I also adapted the README.
