### PR TITLE
add origin_request_policy_id & cache_policy_id to caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ module "cdn" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6 |
-| aws | >= 3.0 |
+| aws | >= 3.28.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| aws | >= 3.28.0 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ module "cdn" {
 |------|---------|
 | aws | >= 3.28.0 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudfront_distribution](https://registry.terraform.io/providers/hashicorp/aws/3.28.0/docs/resources/cloudfront_distribution) |
+| [aws_cloudfront_origin_access_identity](https://registry.terraform.io/providers/hashicorp/aws/3.28.0/docs/resources/cloudfront_origin_access_identity) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -148,7 +159,6 @@ module "cdn" {
 | this\_cloudfront\_origin\_access\_identities | The origin access identities created |
 | this\_cloudfront\_origin\_access\_identity\_iam\_arns | The IAM arns of the origin access identities created |
 | this\_cloudfront\_origin\_access\_identity\_ids | The IDS of the origin access identities created |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -27,7 +27,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6 |
-| aws | >= 3.0 |
+| aws | >= 3.28.0 |
 | null | ~> 2 |
 | random | ~> 2 |
 
@@ -35,9 +35,32 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| aws | >= 3.28.0 |
 | null | ~> 2 |
 | random | ~> 2 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| acm | terraform-aws-modules/acm/aws | ~> 2.0 |
+| cloudfront | ../../ |  |
+| lambda_function | terraform-aws-modules/lambda/aws | ~> 1.0 |
+| log_bucket | terraform-aws-modules/s3-bucket/aws |  |
+| records | terraform-aws-modules/route53/aws//modules/records |  |
+| s3_one | terraform-aws-modules/s3-bucket/aws |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_canonical_user_id](https://registry.terraform.io/providers/hashicorp/aws/3.28.0/docs/data-sources/canonical_user_id) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.28.0/docs/data-sources/iam_policy_document) |
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/3.28.0/docs/data-sources/route53_zone) |
+| [aws_s3_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/3.28.0/docs/resources/s3_bucket_policy) |
+| [null_data_source](https://registry.terraform.io/providers/hashicorp/null/2/docs/data-sources/data_source) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/2/docs/resources/resource) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
 
 ## Inputs
 
@@ -60,5 +83,4 @@ No input.
 | this\_cloudfront\_origin\_access\_identities | The origin access identities created |
 | this\_cloudfront\_origin\_access\_identity\_iam\_arns | The IAM arns of the origin access identities created |
 | this\_cloudfront\_origin\_access\_identity\_ids | The IDS of the origin access identities created |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 3.0"
+    aws    = ">= 3.28.0"
     random = "~> 2"
     null   = "~> 2"
   }

--- a/main.tf
+++ b/main.tf
@@ -105,8 +105,8 @@ resource "aws_cloudfront_distribution" "this" {
       smooth_streaming          = lookup(i.value, "smooth_streaming", null)
       trusted_signers           = lookup(i.value, "trusted_signers", null)
 
-      cache_policy_id           = lookup(i.value, "cache_policy_id", null)
-      origin_request_policy_id  = lookup(i.value, "origin_request_policy_id", null)
+      cache_policy_id          = lookup(i.value, "cache_policy_id", null)
+      origin_request_policy_id = lookup(i.value, "origin_request_policy_id", null)
 
       min_ttl     = lookup(i.value, "min_ttl", null)
       default_ttl = lookup(i.value, "default_ttl", null)
@@ -152,8 +152,8 @@ resource "aws_cloudfront_distribution" "this" {
       smooth_streaming          = lookup(i.value, "smooth_streaming", null)
       trusted_signers           = lookup(i.value, "trusted_signers", null)
 
-      cache_policy_id           = lookup(i.value, "cache_policy_id", null)
-      origin_request_policy_id  = lookup(i.value, "origin_request_policy_id", null)
+      cache_policy_id          = lookup(i.value, "cache_policy_id", null)
+      origin_request_policy_id = lookup(i.value, "origin_request_policy_id", null)
 
       min_ttl     = lookup(i.value, "min_ttl", null)
       default_ttl = lookup(i.value, "default_ttl", null)

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,9 @@ resource "aws_cloudfront_distribution" "this" {
       smooth_streaming          = lookup(i.value, "smooth_streaming", null)
       trusted_signers           = lookup(i.value, "trusted_signers", null)
 
+      cache_policy_id           = lookup(i.value, "cache_policy_id", null)
+      origin_request_policy_id  = lookup(i.value, "origin_request_policy_id", null)
+
       min_ttl     = lookup(i.value, "min_ttl", null)
       default_ttl = lookup(i.value, "default_ttl", null)
       max_ttl     = lookup(i.value, "max_ttl", null)
@@ -148,6 +151,9 @@ resource "aws_cloudfront_distribution" "this" {
       field_level_encryption_id = lookup(i.value, "field_level_encryption_id", null)
       smooth_streaming          = lookup(i.value, "smooth_streaming", null)
       trusted_signers           = lookup(i.value, "trusted_signers", null)
+
+      cache_policy_id           = lookup(i.value, "cache_policy_id", null)
+      origin_request_policy_id  = lookup(i.value, "origin_request_policy_id", null)
 
       min_ttl     = lookup(i.value, "min_ttl", null)
       default_ttl = lookup(i.value, "default_ttl", null)

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 3.0"
+    aws = ">= 3.28.0"
   }
 }


### PR DESCRIPTION
## Description
Recently, AWS started to offer to assigned managed policies to caching:
- Managed-CachingOptimized
- Managed-CachingDisabled
- Managed-CachingOptimizedForUncompressedObjects
- Managed-Elemental-MediaPackage

## Motivation and Context
This change is considered to be like a step to easier setup of CF.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
Tested on creation of the new resource / update of resource created w/o managed policy.
If CDN was created w/o managed policy, it possibly would throw an error in time of apply:
`The parameter ForwardedValues cannot be used when a cache policy is associated to the cache behavior.`
