### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/README.md
+++ b/README.md
@@ -95,70 +95,70 @@ module "cdn" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 3.28.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.28.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28.0 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_cloudfront_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) |
-| [aws_cloudfront_origin_access_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) |
+| Name | Type |
+|------|------|
+| [aws_cloudfront_distribution.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
+| [aws_cloudfront_origin_access_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| aliases | Extra CNAMEs (alternate domain names), if any, for this distribution. | `list(string)` | `null` | no |
-| comment | Any comments you want to include about the distribution. | `string` | `null` | no |
-| create\_distribution | Controls if CloudFront distribution should be created | `bool` | `true` | no |
-| create\_origin\_access\_identity | Controls if CloudFront origin access identity should be created | `bool` | `false` | no |
-| custom\_error\_response | One or more custom error response elements | `any` | `{}` | no |
-| default\_cache\_behavior | The default cache behavior for this distribution | `any` | `null` | no |
-| default\_root\_object | The object that you want CloudFront to return (for example, index.html) when an end user requests the root URL. | `string` | `null` | no |
-| enabled | Whether the distribution is enabled to accept end user requests for content. | `bool` | `true` | no |
-| geo\_restriction | The restriction configuration for this distribution (geo\_restrictions) | `any` | `{}` | no |
-| http\_version | The maximum HTTP version to support on the distribution. Allowed values are http1.1 and http2. The default is http2. | `string` | `"http2"` | no |
-| is\_ipv6\_enabled | Whether the IPv6 is enabled for the distribution. | `bool` | `null` | no |
-| logging\_config | The logging configuration that controls how logs are written to your distribution (maximum one). | `any` | `{}` | no |
-| ordered\_cache\_behavior | An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0. | `any` | `[]` | no |
-| origin | One or more origins for this distribution (multiples allowed). | `any` | `null` | no |
-| origin\_access\_identities | Map of CloudFront origin access identities (value as a comment) | `map(string)` | `{}` | no |
-| origin\_group | One or more origin\_group for this distribution (multiples allowed). | `any` | `{}` | no |
-| price\_class | The price class for this distribution. One of PriceClass\_All, PriceClass\_200, PriceClass\_100 | `string` | `null` | no |
-| retain\_on\_delete | Disables the distribution instead of deleting it when destroying the resource through Terraform. If this is set, the distribution needs to be deleted manually afterwards. | `bool` | `false` | no |
-| tags | A map of tags to assign to the resource. | `map(string)` | `null` | no |
-| viewer\_certificate | The SSL configuration for this distribution | `any` | <pre>{<br>  "cloudfront_default_certificate": true,<br>  "minimum_protocol_version": "TLSv1"<br>}</pre> | no |
-| wait\_for\_deployment | If enabled, the resource will wait for the distribution status to change from InProgress to Deployed. Setting this tofalse will skip the process. | `bool` | `true` | no |
-| web\_acl\_id | If you're using AWS WAF to filter CloudFront requests, the Id of the AWS WAF web ACL that is associated with the distribution. The WAF Web ACL must exist in the WAF Global (CloudFront) region and the credentials configuring this argument must have waf:GetWebACL permissions assigned. If using WAFv2, provide the ARN of the web ACL. | `string` | `null` | no |
+| <a name="input_aliases"></a> [aliases](#input\_aliases) | Extra CNAMEs (alternate domain names), if any, for this distribution. | `list(string)` | `null` | no |
+| <a name="input_comment"></a> [comment](#input\_comment) | Any comments you want to include about the distribution. | `string` | `null` | no |
+| <a name="input_create_distribution"></a> [create\_distribution](#input\_create\_distribution) | Controls if CloudFront distribution should be created | `bool` | `true` | no |
+| <a name="input_create_origin_access_identity"></a> [create\_origin\_access\_identity](#input\_create\_origin\_access\_identity) | Controls if CloudFront origin access identity should be created | `bool` | `false` | no |
+| <a name="input_custom_error_response"></a> [custom\_error\_response](#input\_custom\_error\_response) | One or more custom error response elements | `any` | `{}` | no |
+| <a name="input_default_cache_behavior"></a> [default\_cache\_behavior](#input\_default\_cache\_behavior) | The default cache behavior for this distribution | `any` | `null` | no |
+| <a name="input_default_root_object"></a> [default\_root\_object](#input\_default\_root\_object) | The object that you want CloudFront to return (for example, index.html) when an end user requests the root URL. | `string` | `null` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the distribution is enabled to accept end user requests for content. | `bool` | `true` | no |
+| <a name="input_geo_restriction"></a> [geo\_restriction](#input\_geo\_restriction) | The restriction configuration for this distribution (geo\_restrictions) | `any` | `{}` | no |
+| <a name="input_http_version"></a> [http\_version](#input\_http\_version) | The maximum HTTP version to support on the distribution. Allowed values are http1.1 and http2. The default is http2. | `string` | `"http2"` | no |
+| <a name="input_is_ipv6_enabled"></a> [is\_ipv6\_enabled](#input\_is\_ipv6\_enabled) | Whether the IPv6 is enabled for the distribution. | `bool` | `null` | no |
+| <a name="input_logging_config"></a> [logging\_config](#input\_logging\_config) | The logging configuration that controls how logs are written to your distribution (maximum one). | `any` | `{}` | no |
+| <a name="input_ordered_cache_behavior"></a> [ordered\_cache\_behavior](#input\_ordered\_cache\_behavior) | An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0. | `any` | `[]` | no |
+| <a name="input_origin"></a> [origin](#input\_origin) | One or more origins for this distribution (multiples allowed). | `any` | `null` | no |
+| <a name="input_origin_access_identities"></a> [origin\_access\_identities](#input\_origin\_access\_identities) | Map of CloudFront origin access identities (value as a comment) | `map(string)` | `{}` | no |
+| <a name="input_origin_group"></a> [origin\_group](#input\_origin\_group) | One or more origin\_group for this distribution (multiples allowed). | `any` | `{}` | no |
+| <a name="input_price_class"></a> [price\_class](#input\_price\_class) | The price class for this distribution. One of PriceClass\_All, PriceClass\_200, PriceClass\_100 | `string` | `null` | no |
+| <a name="input_retain_on_delete"></a> [retain\_on\_delete](#input\_retain\_on\_delete) | Disables the distribution instead of deleting it when destroying the resource through Terraform. If this is set, the distribution needs to be deleted manually afterwards. | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resource. | `map(string)` | `null` | no |
+| <a name="input_viewer_certificate"></a> [viewer\_certificate](#input\_viewer\_certificate) | The SSL configuration for this distribution | `any` | <pre>{<br>  "cloudfront_default_certificate": true,<br>  "minimum_protocol_version": "TLSv1"<br>}</pre> | no |
+| <a name="input_wait_for_deployment"></a> [wait\_for\_deployment](#input\_wait\_for\_deployment) | If enabled, the resource will wait for the distribution status to change from InProgress to Deployed. Setting this tofalse will skip the process. | `bool` | `true` | no |
+| <a name="input_web_acl_id"></a> [web\_acl\_id](#input\_web\_acl\_id) | If you're using AWS WAF to filter CloudFront requests, the Id of the AWS WAF web ACL that is associated with the distribution. The WAF Web ACL must exist in the WAF Global (CloudFront) region and the credentials configuring this argument must have waf:GetWebACL permissions assigned. If using WAFv2, provide the ARN of the web ACL. | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_cloudfront\_distribution\_arn | The ARN (Amazon Resource Name) for the distribution. |
-| this\_cloudfront\_distribution\_caller\_reference | Internal value used by CloudFront to allow future updates to the distribution configuration. |
-| this\_cloudfront\_distribution\_domain\_name | The domain name corresponding to the distribution. |
-| this\_cloudfront\_distribution\_etag | The current version of the distribution's information. |
-| this\_cloudfront\_distribution\_hosted\_zone\_id | The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to. |
-| this\_cloudfront\_distribution\_id | The identifier for the distribution. |
-| this\_cloudfront\_distribution\_in\_progress\_validation\_batches | The number of invalidation batches currently in progress. |
-| this\_cloudfront\_distribution\_last\_modified\_time | The date and time the distribution was last modified. |
-| this\_cloudfront\_distribution\_status | The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system. |
-| this\_cloudfront\_distribution\_trusted\_signers | List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs |
-| this\_cloudfront\_origin\_access\_identities | The origin access identities created |
-| this\_cloudfront\_origin\_access\_identity\_iam\_arns | The IAM arns of the origin access identities created |
-| this\_cloudfront\_origin\_access\_identity\_ids | The IDS of the origin access identities created |
+| <a name="output_this_cloudfront_distribution_arn"></a> [this\_cloudfront\_distribution\_arn](#output\_this\_cloudfront\_distribution\_arn) | The ARN (Amazon Resource Name) for the distribution. |
+| <a name="output_this_cloudfront_distribution_caller_reference"></a> [this\_cloudfront\_distribution\_caller\_reference](#output\_this\_cloudfront\_distribution\_caller\_reference) | Internal value used by CloudFront to allow future updates to the distribution configuration. |
+| <a name="output_this_cloudfront_distribution_domain_name"></a> [this\_cloudfront\_distribution\_domain\_name](#output\_this\_cloudfront\_distribution\_domain\_name) | The domain name corresponding to the distribution. |
+| <a name="output_this_cloudfront_distribution_etag"></a> [this\_cloudfront\_distribution\_etag](#output\_this\_cloudfront\_distribution\_etag) | The current version of the distribution's information. |
+| <a name="output_this_cloudfront_distribution_hosted_zone_id"></a> [this\_cloudfront\_distribution\_hosted\_zone\_id](#output\_this\_cloudfront\_distribution\_hosted\_zone\_id) | The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to. |
+| <a name="output_this_cloudfront_distribution_id"></a> [this\_cloudfront\_distribution\_id](#output\_this\_cloudfront\_distribution\_id) | The identifier for the distribution. |
+| <a name="output_this_cloudfront_distribution_in_progress_validation_batches"></a> [this\_cloudfront\_distribution\_in\_progress\_validation\_batches](#output\_this\_cloudfront\_distribution\_in\_progress\_validation\_batches) | The number of invalidation batches currently in progress. |
+| <a name="output_this_cloudfront_distribution_last_modified_time"></a> [this\_cloudfront\_distribution\_last\_modified\_time](#output\_this\_cloudfront\_distribution\_last\_modified\_time) | The date and time the distribution was last modified. |
+| <a name="output_this_cloudfront_distribution_status"></a> [this\_cloudfront\_distribution\_status](#output\_this\_cloudfront\_distribution\_status) | The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system. |
+| <a name="output_this_cloudfront_distribution_trusted_signers"></a> [this\_cloudfront\_distribution\_trusted\_signers](#output\_this\_cloudfront\_distribution\_trusted\_signers) | List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs |
+| <a name="output_this_cloudfront_origin_access_identities"></a> [this\_cloudfront\_origin\_access\_identities](#output\_this\_cloudfront\_origin\_access\_identities) | The origin access identities created |
+| <a name="output_this_cloudfront_origin_access_identity_iam_arns"></a> [this\_cloudfront\_origin\_access\_identity\_iam\_arns](#output\_this\_cloudfront\_origin\_access\_identity\_iam\_arns) | The IAM arns of the origin access identities created |
+| <a name="output_this_cloudfront_origin_access_identity_ids"></a> [this\_cloudfront\_origin\_access\_identity\_ids](#output\_this\_cloudfront\_origin\_access\_identity\_ids) | The IDS of the origin access identities created |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -26,61 +26,61 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 3.28.0 |
-| null | ~> 2 |
-| random | ~> 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.28.0 |
-| null | ~> 2 |
-| random | ~> 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 2 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| acm | terraform-aws-modules/acm/aws | ~> 2.0 |
-| cloudfront | ../../ |  |
-| lambda_function | terraform-aws-modules/lambda/aws | ~> 1.0 |
-| log_bucket | terraform-aws-modules/s3-bucket/aws |  |
-| records | terraform-aws-modules/route53/aws//modules/records |  |
-| s3_one | terraform-aws-modules/s3-bucket/aws |  |
+| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 2.0 |
+| <a name="module_cloudfront"></a> [cloudfront](#module\_cloudfront) | ../../ |  |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 1.0 |
+| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-aws-modules/s3-bucket/aws |  |
+| <a name="module_records"></a> [records](#module\_records) | terraform-aws-modules/route53/aws//modules/records |  |
+| <a name="module_s3_one"></a> [s3\_one](#module\_s3\_one) | terraform-aws-modules/s3-bucket/aws |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_canonical_user_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) |
-| [aws_s3_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) |
-| [null_data_source](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) |
-| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_canonical_user_id.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) | data source |
+| [aws_iam_policy_document.s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [null_data_source.downloaded_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_cloudfront\_distribution\_arn | The ARN (Amazon Resource Name) for the distribution. |
-| this\_cloudfront\_distribution\_caller\_reference | Internal value used by CloudFront to allow future updates to the distribution configuration. |
-| this\_cloudfront\_distribution\_domain\_name | The domain name corresponding to the distribution. |
-| this\_cloudfront\_distribution\_etag | The current version of the distribution's information. |
-| this\_cloudfront\_distribution\_hosted\_zone\_id | The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to. |
-| this\_cloudfront\_distribution\_id | The identifier for the distribution. |
-| this\_cloudfront\_distribution\_in\_progress\_validation\_batches | The number of invalidation batches currently in progress. |
-| this\_cloudfront\_distribution\_last\_modified\_time | The date and time the distribution was last modified. |
-| this\_cloudfront\_distribution\_status | The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system. |
-| this\_cloudfront\_distribution\_trusted\_signers | List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs |
-| this\_cloudfront\_origin\_access\_identities | The origin access identities created |
-| this\_cloudfront\_origin\_access\_identity\_iam\_arns | The IAM arns of the origin access identities created |
-| this\_cloudfront\_origin\_access\_identity\_ids | The IDS of the origin access identities created |
+| <a name="output_this_cloudfront_distribution_arn"></a> [this\_cloudfront\_distribution\_arn](#output\_this\_cloudfront\_distribution\_arn) | The ARN (Amazon Resource Name) for the distribution. |
+| <a name="output_this_cloudfront_distribution_caller_reference"></a> [this\_cloudfront\_distribution\_caller\_reference](#output\_this\_cloudfront\_distribution\_caller\_reference) | Internal value used by CloudFront to allow future updates to the distribution configuration. |
+| <a name="output_this_cloudfront_distribution_domain_name"></a> [this\_cloudfront\_distribution\_domain\_name](#output\_this\_cloudfront\_distribution\_domain\_name) | The domain name corresponding to the distribution. |
+| <a name="output_this_cloudfront_distribution_etag"></a> [this\_cloudfront\_distribution\_etag](#output\_this\_cloudfront\_distribution\_etag) | The current version of the distribution's information. |
+| <a name="output_this_cloudfront_distribution_hosted_zone_id"></a> [this\_cloudfront\_distribution\_hosted\_zone\_id](#output\_this\_cloudfront\_distribution\_hosted\_zone\_id) | The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to. |
+| <a name="output_this_cloudfront_distribution_id"></a> [this\_cloudfront\_distribution\_id](#output\_this\_cloudfront\_distribution\_id) | The identifier for the distribution. |
+| <a name="output_this_cloudfront_distribution_in_progress_validation_batches"></a> [this\_cloudfront\_distribution\_in\_progress\_validation\_batches](#output\_this\_cloudfront\_distribution\_in\_progress\_validation\_batches) | The number of invalidation batches currently in progress. |
+| <a name="output_this_cloudfront_distribution_last_modified_time"></a> [this\_cloudfront\_distribution\_last\_modified\_time](#output\_this\_cloudfront\_distribution\_last\_modified\_time) | The date and time the distribution was last modified. |
+| <a name="output_this_cloudfront_distribution_status"></a> [this\_cloudfront\_distribution\_status](#output\_this\_cloudfront\_distribution\_status) | The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system. |
+| <a name="output_this_cloudfront_distribution_trusted_signers"></a> [this\_cloudfront\_distribution\_trusted\_signers](#output\_this\_cloudfront\_distribution\_trusted\_signers) | List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs |
+| <a name="output_this_cloudfront_origin_access_identities"></a> [this\_cloudfront\_origin\_access\_identities](#output\_this\_cloudfront\_origin\_access\_identities) | The origin access identities created |
+| <a name="output_this_cloudfront_origin_access_identity_iam_arns"></a> [this\_cloudfront\_origin\_access\_identity\_iam\_arns](#output\_this\_cloudfront\_origin\_access\_identity\_iam\_arns) | The IAM arns of the origin access identities created |
+| <a name="output_this_cloudfront_origin_access_identity_ids"></a> [this\_cloudfront\_origin\_access\_identity\_ids](#output\_this\_cloudfront\_origin\_access\_identity\_ids) | The IDS of the origin access identities created |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
