### PR TITLE
Move custom_error_response into array

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -201,7 +201,7 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   dynamic "custom_error_response" {
-    for_each = var.custom_error_response
+    for_each = [var.custom_error_response]
 
     content {
       error_code = custom_error_response.value["error_code"]


### PR DESCRIPTION
## Description
I've moved `custom_error_response` within `custom_error_response` dynamic block into the array. 
Without that `custom_error_response.value` references to value of each key in the `custom_error_response` map. 

## Motivation and Context
```
  on .terraform/modules/platform_distribution.platform_distribution/main.tf line 210, in resource "aws_cloudfront_distribution" "this":
 210:       response_page_path    = lookup(custom_error_response.value, "response_page_path", null)
    |----------------
    | custom_error_response.value is "/index.html"

Invalid value for "inputMap" parameter: lookup() requires a map as the first
argument.

  on .terraform/modules/platform_distribution.platform_distribution/main.tf line 211, in resource "aws_cloudfront_distribution" "this":
 211:       error_caching_min_ttl = lookup(custom_error_response.value, "error_caching_min_ttl", null)
    |----------------
    | custom_error_response.value is "20"

Invalid value for "inputMap" parameter: lookup() requires a map as the first
argument.
```
## Breaking Changes
I don't think it does break anything. 

## How Has This Been Tested?
I've applied it and tested it in my environment.
