### PR TITLE
fix: Use empty origin_path by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_cloudfront_distribution" "this" {
     content {
       domain_name = origin.value.domain_name
       origin_id   = lookup(origin.value, "origin_id", origin.key)
-      origin_path = lookup(origin.value, "origin_path", null)
+      origin_path = lookup(origin.value, "origin_path", "")
 
       dynamic "s3_origin_config" {
         for_each = length(keys(lookup(origin.value, "s3_origin_config", {}))) == 0 ? [] : [lookup(origin.value, "s3_origin_config", {})]


### PR DESCRIPTION
Provide empty string as default origin path in order to avoid unneces…

## Description
This change replaces the default value of origin_path from null to an empty string

## Motivation and Context
If this value remains as null, instead of an empty string, it keeps recreating the resource at every modification, however small it maybe: adding a new origin or even so small as modifying the domain_name for a custom-origin in CDN

<!--- If it fixes an open issue, please link to the issue here. -->
This is related to an Open PR on aws-provider for Terraform at https://github.com/hashicorp/terraform-provider-aws/issues/12065 and is a suggestion from wamonite on the thread that points out that a regular _terraform plan_ wouldn't show the variation in origin_path attribute. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
Does not break anything as null is simply replaced by an empty string

<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [YES ] I have tested and validated these changes using one or more of the provided `examples/*` projects
Making this change only provides a default value, instead of actually overriding any value that a customer may have wanted
Also, this does not lead to any real applies if you were to try _terraform apply_

