### PR TITLE
fix: Use empty list for headers by default instead of null

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ resource "aws_cloudfront_distribution" "this" {
         content {
           query_string            = lookup(i.value, "query_string", false)
           query_string_cache_keys = lookup(i.value, "query_string_cache_keys", [])
-          headers                 = lookup(i.value, "headers", null)
+          headers                 = lookup(i.value, "headers", [])
 
           cookies {
             forward           = lookup(i.value, "cookies_forward", "none")
@@ -171,7 +171,7 @@ resource "aws_cloudfront_distribution" "this" {
         content {
           query_string            = lookup(i.value, "query_string", false)
           query_string_cache_keys = lookup(i.value, "query_string_cache_keys", [])
-          headers                 = lookup(i.value, "headers", null)
+          headers                 = lookup(i.value, "headers", [])
 
           cookies {
             forward           = lookup(i.value, "cookies_forward", "none")


### PR DESCRIPTION
## Description
Defaulting "Cache Based on Selected Request Headers" to an empty string

## Motivation and Context
The headers are never updated or picked up by Terraform consistently, because they are defaulted to null. Due to this, when you wish to remove the attribute (say, "Accept" header), it simply won't accept an empty string in a list and throw an error. Removing the attribute (or even commenting it) altogether doesn't help either: it is simply ignored by Terraform provider! 

I wanted to open an Issue, but I already found the root cause and solution, and so no issue was opened by me

## Breaking Changes
It does not break anything and only sets a default value of an empty string


## How Has This Been Tested?
- [x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
I tested it on my enterprise staging environment
Terraform version: v0.13.7
aws Provider: 3.28
