### PR TITLE
feat: Support for CloudFront Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ module "cdn" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.37.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.41.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.37.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.41.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ module "cdn" {
 
 ## Examples:
 
-- [Complete](https://github.com/terraform-aws-modules/terraform-aws-cloudfront/tree/master/examples/complete) - Complete example which creates AWS CloudFront distribution and integrates it with other [terraform-aws-modules](https://github.com/terraform-aws-modules) to create additional resources: S3 buckets, Lambda Functions, ACM Certificate, Route53 Records.
+- [Complete](https://github.com/terraform-aws-modules/terraform-aws-cloudfront/tree/master/examples/complete) - Complete example which creates AWS CloudFront distribution and integrates it with other [terraform-aws-modules](https://github.com/terraform-aws-modules) to create additional resources: S3 buckets, Lambda Functions, CloudFront Functions, ACM Certificate, Route53 Records.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -54,6 +54,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
+| [aws_cloudfront_function.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |

--- a/examples/complete/example-function.js
+++ b/examples/complete/example-function.js
@@ -1,0 +1,13 @@
+function handler(event) {
+  // NOTE: This example function is for a viewer request event trigger. 
+  // Choose viewer request for event trigger when you associate this function with a distribution. 
+  var response = {
+    statusCode: 302,
+    statusDescription: 'Found',
+    headers: {
+      'cloudfront-functions': { value: 'generated-by-CloudFront-Functions' },
+      'location': { value: 'https://aws.amazon.com/cloudfront/' }
+    }
+  };
+  return response;
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -98,6 +98,13 @@ module "cloudfront" {
         lambda_arn = module.lambda_function.lambda_function_qualified_arn
       }
     }
+
+    function_association = {
+      # Valid keys: viewer-request, viewer-response
+      viewer-response = {
+        function_arn = aws_cloudfront_function.example.arn
+      }
+    }
   }
 
   ordered_cache_behavior = [
@@ -270,3 +277,8 @@ resource "random_pet" "this" {
   length = 2
 }
 
+resource "aws_cloudfront_function" "example" {
+  name    = "example"
+  runtime = "cloudfront-js-1.0"
+  code    = file("example-function.js")
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -12,7 +12,7 @@ provider "aws" {
 }
 
 locals {
-  domain_name = "beautypie-sandbox.com" # trimsuffix(data.aws_route53_zone.this.name, ".")
+  domain_name = "terraform-aws-modules.modules.tf" # trimsuffix(data.aws_route53_zone.this.name, ".")
   subdomain   = "cdn"
 }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -101,7 +101,7 @@ module "cloudfront" {
 
     function_association = {
       # Valid keys: viewer-request, viewer-response
-      viewer-response = {
+      viewer-request = {
         function_arn = aws_cloudfront_function.example.arn
       }
     }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -12,7 +12,7 @@ provider "aws" {
 }
 
 locals {
-  domain_name = "terraform-aws-modules.modules.tf" # trimsuffix(data.aws_route53_zone.this.name, ".")
+  domain_name = "beautypie-sandbox.com" # trimsuffix(data.aws_route53_zone.this.name, ".")
   subdomain   = "cdn"
 }
 
@@ -96,17 +96,6 @@ module "cloudfront" {
 
       origin-request = {
         lambda_arn = module.lambda_function.lambda_function_qualified_arn
-      }
-    }
-
-    function_association = {
-      # Valid keys: viewer-request, viewer-response
-      viewer-request = {
-        function_arn = aws_cloudfront_function.example.arn
-      }
-
-      viewer-response = {
-        function_arn = aws_cloudfront_function.example.arn
       }
     }
   }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -104,6 +104,10 @@ module "cloudfront" {
       viewer-request = {
         function_arn = aws_cloudfront_function.example.arn
       }
+
+      viewer-response = {
+        function_arn = aws_cloudfront_function.example.arn
+      }
     }
   }
 
@@ -117,6 +121,17 @@ module "cloudfront" {
       cached_methods  = ["GET", "HEAD"]
       compress        = true
       query_string    = true
+
+      function_association = {
+        # Valid keys: viewer-request, viewer-response
+        viewer-request = {
+          function_arn = aws_cloudfront_function.example.arn
+        }
+
+        viewer-response = {
+          function_arn = aws_cloudfront_function.example.arn
+        }
+      }
     }
   ]
 
@@ -278,7 +293,7 @@ resource "random_pet" "this" {
 }
 
 resource "aws_cloudfront_function" "example" {
-  name    = "example"
+  name    = "example-${random_pet.this.id}"
   runtime = "cloudfront-js-1.0"
   code    = file("example-function.js")
 }

--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ resource "aws_cloudfront_distribution" "this" {
 
         content {
           event_type   = f.key
-          function_arn = f.value.lambda_arn
+          function_arn = f.value.function_arn
         }
       }
     }
@@ -207,7 +207,7 @@ resource "aws_cloudfront_distribution" "this" {
 
         content {
           event_type   = f.key
-          function_arn = f.value.lambda_arn
+          function_arn = f.value.function_arn
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,16 @@ resource "aws_cloudfront_distribution" "this" {
           include_body = lookup(l.value, "include_body", null)
         }
       }
+
+      dynamic "function_association" {
+        for_each = lookup(i.value, "function_association", [])
+        iterator = f
+
+        content {
+          event_type   = f.key
+          function_arn = f.value.lambda_arn
+        }
+      }
     }
   }
 
@@ -188,6 +198,16 @@ resource "aws_cloudfront_distribution" "this" {
           event_type   = l.key
           lambda_arn   = l.value.lambda_arn
           include_body = lookup(l.value, "include_body", null)
+        }
+      }
+
+      dynamic "function_association" {
+        for_each = lookup(i.value, "function_association", [])
+        iterator = f
+
+        content {
+          event_type   = f.key
+          function_arn = f.value.lambda_arn
         }
       }
     }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 3.37.0"
+    aws = ">= 3.41.0"
   }
 }


### PR DESCRIPTION
## Description
Adds support for [CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html) - Terraform docs at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#function-association

## Motivation and Context
Supporting new functionality

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
I'm in the process of testing this in a private project, but I'm opening this PR already for some feedback
