### PR TITLE
Fix default value for lambda_function_association

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ resource "aws_cloudfront_distribution" "this" {
       }
 
       dynamic "lambda_function_association" {
-        for_each = lookup(i.value, "lambda_function_association", [])
+        for_each = lookup(i.value, "lambda_function_association", {})
         iterator = l
 
         content {
@@ -181,7 +181,7 @@ resource "aws_cloudfront_distribution" "this" {
       }
 
       dynamic "lambda_function_association" {
-        for_each = lookup(i.value, "lambda_function_association", [])
+        for_each = lookup(i.value, "lambda_function_association", {})
         iterator = l
 
         content {


### PR DESCRIPTION
## Description
Default value for **lambda_function_association** should be an iterable object /map

## Motivation and Context
The following code
```
lambda_function_association = {
  origin-request = {
    lambda_arn = data.aws_lambda_function.lambda.qualified_arn
  }
}
```
is failing with an error 
Error: Invalid dynamic for_each value
on .terraform/modules/download.cloudfront_disribution/main.tf line 132, in resource "aws_cloudfront_distribution" "this":
  132:         for_each = lookup(i.value, "lambda_function_association", [])
     ├────────────────
     │ i.value is (sensitive value)
     │ 
     │ Cannot use a object value in for_each. An iterable collection is required.

## Breaking Changes
No

## How Has This Been Tested?
- [ x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
