### PR TITLE
Add support for origin_shield configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,15 @@ resource "aws_cloudfront_distribution" "this" {
           value = custom_header.value.value
         }
       }
+
+      dynamic "origin_shield" {
+        for_each = length(lookup(origin.value, "origin_shield", "")) == 0 ? [] : [lookup(origin.value, "origin_shield", "")]
+
+        content {
+          enabled = origin_shield.value.enabled
+          origin_shield_region = origin_shield.value.origin_shield_region
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Add support for `origin_shield` configuration (see [Terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin-shield-arguments)).

## Motivation and Context
I imported my CloudFront distribution with a configured Origin Shield. Then I was not able to produce the plan to match it as Terraform was planning to replace the current `origin` with a new one without Origin Shield:

```
Terraform will perform the following actions:

  # aws_cloudfront_distribution.this[0] will be updated in-place
  ~ resource "aws_cloudfront_distribution" "this" {
      ...
      - origin {
         ...
          - origin_shield {
              - enabled              = true -> null
              - origin_shield_region = "eu-central-1" -> null
            }
        }
      + origin {
          ...    # no origin_shield section
        }
```

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
I have tested and validated these changes by changing 
```
terraform {
  source = "git::git@github.com:terraform-aws-modules/terraform-aws-cloudfront.git//.?ref=v2.5.0"
}
```

with a 
```
terraform {
  source = "git::git@github.com:vbalys/terraform-aws-cloudfront.git//.?ref=v2.6.0"
}
```

With this update and `origin` configuration including `origin_shield` section I got a plan with no changes. 
```
origin {
  ...
  origin_shield {
    enabled = true
    origin_shield_region = "eu-central-1"
  }
}
```

Additionally, I checked that if any of the [required arguments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin-shield-arguments) is missing, `terragrunt plan` will raise error about unknown attribute:
```
origin_shield = {
  enabled = true
}
```
--> 
```
╷
│ Error: Unsupported attribute
│ 
│   on main.tf line 76, in resource "aws_cloudfront_distribution" "this":
│   76:           origin_shield_region = origin_shield.value.origin_shield_region
│     ├────────────────
│     │ origin_shield.value is object with 1 attribute "enabled"
│ 
│ This object does not have an attribute named "origin_shield_region".
```