### PR TITLE
Fix path of example in module record :tea:

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -236,7 +236,7 @@ module "lambda_function" {
 ##########
 
 module "records" {
-  source  = "terraform-aws-modules/route53/aws//modules/records"
+  source  = "terraform-aws-modules/route53/aws/modules/records"
   version = "~> 2.0"
 
   zone_id = data.aws_route53_zone.this.zone_id


### PR DESCRIPTION
It's just a quick fix of path to import module from another module.