### PR TITLE
fix Broken example with records v2.1.0

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -236,7 +236,7 @@ module "lambda_function" {
 ##########
 
 module "records" {
-  source  = "terraform-aws-modules/route53/aws/modules/records"
+  source  = "terraform-aws-modules/route53/aws//modules/records"
   version = "2.0.0"
 
   zone_id = data.aws_route53_zone.this.zone_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -236,7 +236,7 @@ module "lambda_function" {
 ##########
 
 module "records" {
-  source  = "terraform-aws-modules/route53/aws//modules/records"
+  source  = "terraform-aws-modules/route53/aws/modules/records"
   version = "~> 2.0"
 
   zone_id = data.aws_route53_zone.this.zone_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -237,7 +237,7 @@ module "lambda_function" {
 
 module "records" {
   source  = "terraform-aws-modules/route53/aws/modules/records"
-  version = "~> 2.0"
+  version = "2.0.0"
 
   zone_id = data.aws_route53_zone.this.zone_id
 


### PR DESCRIPTION
## Description
After I use the records following the example and got stuck with this error

```bash
│ Error: Invalid for_each argument
│
│   on .terraform/modules/route53_records.route53_records/modules/records/main.tf line 19, in resource "aws_route53_record" "this":
│   19:   for_each = var.create && (var.zone_id != null || var.zone_name != null) ? local.recordsets : tomap({})
│     ├────────────────
│     │ local.recordsets will be known only after apply
│     │ var.create is true
│     │ var.zone_id is "ZONE_ID"
│     │ var.zone_name is null
```

## Motivation and Context
The new code in submodule for route53 break our example.
```terraform
records = try(jsondecode(var.records), var.records)
```

## Breaking Changes
It's work normally after fix with this PR.

## How Has This Been Tested?
- I have tested and validated these changes using one or more of the provided `examples/*` projects
- Yes
