### PR TITLE
docs: Add TLSv1.1 and TLSv1.2 for origin_ssl_protocols in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ module "cdn" {
         http_port              = 80
         https_port             = 443
         origin_protocol_policy = "match-viewer"
-        origin_ssl_protocols   = ["TLSv1"]
+        origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
       }
     }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -45,7 +45,7 @@ module "cloudfront" {
         http_port              = 80
         https_port             = 443
         origin_protocol_policy = "match-viewer"
-        origin_ssl_protocols   = ["TLSv1"]
+        origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
       }
 
       custom_header = [


### PR DESCRIPTION
## Description
Add `TLSv1.1` and `TLSv1.2` in `origin_ssl_protocols` examples.

## Motivation and Context
TLSv1 is deprecated. We should encourage usage of TLSv1.2 everywhere, hence adding it in examples.

## Breaking Changes
No breaking changes, protocols have been added.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

I did not test changes as it's in the documentation.