### PR TITLE
build: remove max version constraint

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -246,7 +246,7 @@ module "lambda_function" {
 
 module "records" {
   source  = "terraform-aws-modules/route53/aws//modules/records"
-  version = "2.0.0" # @todo: revert to "~> 2.0" once 2.1.0 is fixed properly
+  version = "~> 2.0"
 
   zone_id = data.aws_route53_zone.this.zone_id
 


### PR DESCRIPTION
## Description
Is the max version constraint still necessary?
Has the problem in 2.1.0 been fixed properly, since the module is now at 2.3.0?

## Motivation and Context
Might be vestigial remnants

## Breaking Changes
none known

## How Has This Been Tested?
