### PR TITLE
Support dual-stack access to the distribution

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -23,7 +23,7 @@ module "cloudfront" {
 
   comment             = "My awesome CloudFront"
   enabled             = true
-  is_ipv6_enabled     = true
+  is_ipv6_enabled     = var.enable_ipv6
   price_class         = "PriceClass_All"
   retain_on_delete    = false
   wait_for_deployment = false
@@ -248,7 +248,7 @@ module "lambda_function" {
 
 module "records" {
   source  = "terraform-aws-modules/route53/aws//modules/records"
-  version = "2.0.0" # @todo: revert to "~> 2.0" once 2.1.0 is fixed properly
+  version = "~> 2.3.0"
 
   zone_id = data.aws_route53_zone.this.zone_id
 
@@ -256,6 +256,26 @@ module "records" {
     {
       name = local.subdomain
       type = "A"
+      alias = {
+        name    = module.cloudfront.cloudfront_distribution_domain_name
+        zone_id = module.cloudfront.cloudfront_distribution_hosted_zone_id
+      }
+    },
+  ]
+}
+
+module "records_ipv6" {
+  source  = "terraform-aws-modules/route53/aws//modules/records"
+  version = "~> 2.3.0"
+
+  zone_id = data.aws_route53_zone.this.zone_id
+
+  count = var.enable_ipv6 ? 1 : 0
+
+  records = [
+    {
+      name = local.subdomain
+      type = "AAAA"
       alias = {
         name    = module.cloudfront.cloudfront_distribution_domain_name
         zone_id = module.cloudfront.cloudfront_distribution_hosted_zone_id

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,0 +1,5 @@
+variable "enable_ipv6" {
+  type        = bool
+  default     = true
+  description = "Description: Whether to enable IPv6 for the distribution."
+}


### PR DESCRIPTION
## Description
Support dual-stack (IPv4 and IPv6) access to the distribution

## Motivation and Context
This example provided only IPv4

## Breaking Changes
I upgraded the Route53 `records` submodule to its current recommended version,
but I did not upgrade the `acm`, `s3-bucket`, or `lambda` modules similarly 
because I haven't tested those versions in this context.

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
I employed these changes in my own distribution