### PR TITLE
feat:Added cloudfront_distribution_aliases output

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cloudfront_distribution_aliases"></a> [cloudfront\_distribution\_aliases](#output\_cloudfront\_distribution\_aliases) | The aliases for the distribution. |
 | <a name="output_cloudfront_distribution_arn"></a> [cloudfront\_distribution\_arn](#output\_cloudfront\_distribution\_arn) | The ARN (Amazon Resource Name) for the distribution. |
 | <a name="output_cloudfront_distribution_caller_reference"></a> [cloudfront\_distribution\_caller\_reference](#output\_cloudfront\_distribution\_caller\_reference) | Internal value used by CloudFront to allow future updates to the distribution configuration. |
 | <a name="output_cloudfront_distribution_domain_name"></a> [cloudfront\_distribution\_domain\_name](#output\_cloudfront\_distribution\_domain\_name) | The domain name corresponding to the distribution. |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -54,7 +54,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
-| [aws_cloudfront_function.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
+| [aws_cloudfront_function.example](https://registry.ter3.1.0
+3.1.0raform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
@@ -70,6 +71,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cloudfront_distribution_aliases"></a> [cloudfront\_distribution\_aliases](#output\_cloudfront\_distribution\_aliases) | The ARN (Amazon Resource Name) for the distribution. |
 | <a name="output_cloudfront_distribution_arn"></a> [cloudfront\_distribution\_arn](#output\_cloudfront\_distribution\_arn) | The ARN (Amazon Resource Name) for the distribution. |
 | <a name="output_cloudfront_distribution_caller_reference"></a> [cloudfront\_distribution\_caller\_reference](#output\_cloudfront\_distribution\_caller\_reference) | Internal value used by CloudFront to allow future updates to the distribution configuration. |
 | <a name="output_cloudfront_distribution_domain_name"></a> [cloudfront\_distribution\_domain\_name](#output\_cloudfront\_distribution\_domain\_name) | The domain name corresponding to the distribution. |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -8,6 +8,11 @@ output "cloudfront_distribution_arn" {
   value       = module.cloudfront.cloudfront_distribution_arn
 }
 
+output "cloudfront_distribution_aliases" {
+  description = "The ARN (Amazon Resource Name) for the distribution."
+  value       = module.cloudfront.cloudfront_distribution_aliases
+}
+
 output "cloudfront_distribution_caller_reference" {
   description = "Internal value used by CloudFront to allow future updates to the distribution configuration."
   value       = module.cloudfront.cloudfront_distribution_caller_reference

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "cloudfront_distribution_arn" {
   value       = element(concat(aws_cloudfront_distribution.this.*.arn, [""]), 0)
 }
 
+output "cloudfront_distribution_aliases" {
+  description = "The aliases for the distribution."
+  value       = element(concat(aws_cloudfront_distribution.this.*.aliases, [""]), 0)
+}
+
 output "cloudfront_distribution_caller_reference" {
   description = "Internal value used by CloudFront to allow future updates to the distribution configuration."
   value       = element(concat(aws_cloudfront_distribution.this.*.caller_reference, [""]), 0)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This adds cloudfront_distribution_aliases output
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Imagine you want to add an alias to an existing Cloudfront Distribution.
SInce there is no API endpoint to only update aliases, you have to provide a combination of existing aliases and your new alias as a parameter.
It makes life easier if you can retrieve those existing aliases if you used this module to set your initial Cloudfront Distribution
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
no
## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested with complete example