### PR TITLE
fix: Add lifecycle clause for aws_cloudfront_origin_access_identity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,10 @@ resource "aws_cloudfront_origin_access_identity" "this" {
   for_each = local.create_origin_access_identity ? var.origin_access_identities : {}
 
   comment = each.value
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_cloudfront_distribution" "this" {


### PR DESCRIPTION
## Description
Performing an update that requires a new Cloudfront Origin Access (OAI) resource will fail since the current OAI resource is being used and cannot be removed. Setting `create_before_destroy = true` ensures that terraform will only try to remove after the new OAI resource has replaced the old one.

## Motivation and Context
Closes https://github.com/terraform-aws-modules/terraform-aws-cloudfront/issues/61

## Breaking Changes
N/A

## How Has This Been Tested?
Manually on test environment.