### PR TITLE
docs: Wrong definition of s3 grant in example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -185,13 +185,13 @@ module "log_bucket" {
   bucket = "logs-${random_pet.this.id}"
   acl    = null
   grant = [{
-    type        = "CanonicalUser"
-    permissions = ["FULL_CONTROL"]
-    id          = data.aws_canonical_user_id.current.id
+    type       = "CanonicalUser"
+    permission = "FULL_CONTROL"
+    id         = data.aws_canonical_user_id.current.id
     }, {
-    type        = "CanonicalUser"
-    permissions = ["FULL_CONTROL"]
-    id          = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+    type       = "CanonicalUser"
+    permission = "FULL_CONTROL"
+    id         = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
     # Ref. https://github.com/terraform-providers/terraform-provider-aws/issues/12512
     # Ref. https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html
   }]


### PR DESCRIPTION
## Description
Wrong definition of s3 grant in example.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix wrong definition of s3 grant in example.
cf. https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/162

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
example changes only, no source code changes
