### PR TITLE
feat!: Added support for origin_access_control_id, bumped AWS provider version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
@@ -51,7 +51,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
@@ -72,7 +72,7 @@ jobs:
         uses: clowdhaus/terraform-min-max@v1.0.3
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -76,3 +76,5 @@ jobs:
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
+          install-hcledit: true
+          hcledit-version: 0.2.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.75.0
     hooks:
       - id: terraform_fmt
+      - id: terraform_wrapper_module_for_each
       - id: terraform_validate
       - id: terraform_docs
         args:
@@ -23,7 +24,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -159,7 +159,13 @@ No modules.
 
 ## Authors
 
-Module is maintained by [Anton Babenko](https://github.com/antonbabenko) with help from [these awesome contributors](https://github.com/terraform-aws-modules/terraform-aws-cloudfront/graphs/contributors).
+Module is maintained by [Anton Babenko](https://github.com/antonbabenko) with help from these awesome contributors:
+
+<!-- markdownlint-disable no-inline-html -->
+<a href="https://github.com/terraform-aws-modules/terraform-aws-cloudfront/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=terraform-aws-modules/terraform-aws-cloudfront" />
+</a>
+<!-- markdownlint-enable no-inline-html -->
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ module "cdn" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.29 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.29 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -27,7 +27,9 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.29 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 1.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
@@ -35,7 +37,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.29 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
@@ -43,12 +45,12 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 3.0 |
+| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 4.0 |
 | <a name="module_cloudfront"></a> [cloudfront](#module\_cloudfront) | ../../ | n/a |
-| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 2.0 |
-| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2.0 |
-| <a name="module_records"></a> [records](#module\_records) | terraform-aws-modules/route53/aws//modules/records | 2.0.0 |
-| <a name="module_s3_one"></a> [s3\_one](#module\_s3\_one) | terraform-aws-modules/s3-bucket/aws | ~> 2.0 |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 4.0 |
+| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
+| <a name="module_records"></a> [records](#module\_records) | terraform-aws-modules/route53/aws//modules/records | ~> 2.0 |
+| <a name="module_s3_one"></a> [s3\_one](#module\_s3\_one) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
 
 ## Resources
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -157,7 +157,7 @@ data "aws_route53_zone" "this" {
 
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   domain_name               = local.domain_name
   zone_id                   = data.aws_route53_zone.this.id
@@ -172,7 +172,7 @@ data "aws_canonical_user_id" "current" {}
 
 module "s3_one" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   bucket        = "s3-one-${random_pet.this.id}"
   force_destroy = true
@@ -180,7 +180,7 @@ module "s3_one" {
 
 module "log_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   bucket = "logs-${random_pet.this.id}"
   acl    = null
@@ -219,7 +219,7 @@ resource "null_resource" "download_package" {
 
 module "lambda_function" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 2.0"
+  version = "~> 4.0"
 
   function_name = "${random_pet.this.id}-lambda"
   description   = "My awesome lambda function"
@@ -248,7 +248,7 @@ module "lambda_function" {
 
 module "records" {
   source  = "terraform-aws-modules/route53/aws//modules/records"
-  version = "2.0.0" # @todo: revert to "~> 2.0" once 2.1.0 is fixed properly
+  version = "~> 2.0"
 
   zone_id = data.aws_route53_zone.this.zone_id
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.64"
+      version = ">= 4.29"
     }
     random = {
       source  = "hashicorp/random"
@@ -13,6 +13,14 @@ terraform {
     null = {
       source  = "hashicorp/null"
       version = ">= 2.0"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 1.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -41,11 +41,12 @@ resource "aws_cloudfront_distribution" "this" {
     for_each = var.origin
 
     content {
-      domain_name         = origin.value.domain_name
-      origin_id           = lookup(origin.value, "origin_id", origin.key)
-      origin_path         = lookup(origin.value, "origin_path", "")
-      connection_attempts = lookup(origin.value, "connection_attempts", null)
-      connection_timeout  = lookup(origin.value, "connection_timeout", null)
+      domain_name              = origin.value.domain_name
+      origin_id                = lookup(origin.value, "origin_id", origin.key)
+      origin_path              = lookup(origin.value, "origin_path", "")
+      connection_attempts      = lookup(origin.value, "connection_attempts", null)
+      connection_timeout       = lookup(origin.value, "connection_timeout", null)
+      origin_access_control_id = lookup(origin.value, "origin_access_control_id", null)
 
       dynamic "s3_origin_config" {
         for_each = length(keys(lookup(origin.value, "s3_origin_config", {}))) == 0 ? [] : [lookup(origin.value, "s3_origin_config", {})]

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.64"
+      version = ">= 4.29"
     }
   }
 }

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -1,0 +1,100 @@
+# Wrapper for the root module
+
+The configuration in this directory contains an implementation of a single module wrapper pattern, which allows managing several copies of a module in places where using the native Terraform 0.13+ `for_each` feature is not feasible (e.g., with Terragrunt).
+
+You may want to use a single Terragrunt configuration file to manage multiple resources without duplicating `terragrunt.hcl` files for each copy of the same module.
+
+This wrapper does not implement any extra functionality.
+
+## Usage with Terragrunt
+
+`terragrunt.hcl`:
+
+```hcl
+terraform {
+  source = "tfr:///terraform-aws-modules/cloudfront/aws//wrappers"
+  # Alternative source:
+  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-cloudfront.git//wrappers?ref=master"
+}
+
+inputs = {
+  defaults = { # Default values
+    create = true
+    tags = {
+      Terraform   = "true"
+      Environment = "dev"
+    }
+  }
+
+  items = {
+    my-item = {
+      # omitted... can be any argument supported by the module
+    }
+    my-second-item = {
+      # omitted... can be any argument supported by the module
+    }
+    # omitted...
+  }
+}
+```
+
+## Usage with Terraform
+
+```hcl
+module "wrapper" {
+  source = "terraform-aws-modules/cloudfront/aws//wrappers"
+
+  defaults = { # Default values
+    create = true
+    tags = {
+      Terraform   = "true"
+      Environment = "dev"
+    }
+  }
+
+  items = {
+    my-item = {
+      # omitted... can be any argument supported by the module
+    }
+    my-second-item = {
+      # omitted... can be any argument supported by the module
+    }
+    # omitted...
+  }
+}
+```
+
+## Example: Manage multiple S3 buckets in one Terragrunt layer
+
+`eu-west-1/s3-buckets/terragrunt.hcl`:
+
+```hcl
+terraform {
+  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
+  # Alternative source:
+  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git//wrappers?ref=master"
+}
+
+inputs = {
+  defaults = {
+    force_destroy = true
+
+    attach_elb_log_delivery_policy        = true
+    attach_lb_log_delivery_policy         = true
+    attach_deny_insecure_transport_policy = true
+    attach_require_latest_tls_policy      = true
+  }
+
+  items = {
+    bucket1 = {
+      bucket = "my-random-bucket-1"
+    }
+    bucket2 = {
+      bucket = "my-random-bucket-2"
+      tags = {
+        Secure = "probably"
+      }
+    }
+  }
+}
+```

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -1,0 +1,33 @@
+module "wrapper" {
+  source = "../"
+
+  for_each = var.items
+
+  create_distribution           = try(each.value.create_distribution, var.defaults.create_distribution, true)
+  create_origin_access_identity = try(each.value.create_origin_access_identity, var.defaults.create_origin_access_identity, false)
+  origin_access_identities      = try(each.value.origin_access_identities, var.defaults.origin_access_identities, {})
+  aliases                       = try(each.value.aliases, var.defaults.aliases, null)
+  comment                       = try(each.value.comment, var.defaults.comment, null)
+  default_root_object           = try(each.value.default_root_object, var.defaults.default_root_object, null)
+  enabled                       = try(each.value.enabled, var.defaults.enabled, true)
+  http_version                  = try(each.value.http_version, var.defaults.http_version, "http2")
+  is_ipv6_enabled               = try(each.value.is_ipv6_enabled, var.defaults.is_ipv6_enabled, null)
+  price_class                   = try(each.value.price_class, var.defaults.price_class, null)
+  retain_on_delete              = try(each.value.retain_on_delete, var.defaults.retain_on_delete, false)
+  wait_for_deployment           = try(each.value.wait_for_deployment, var.defaults.wait_for_deployment, true)
+  web_acl_id                    = try(each.value.web_acl_id, var.defaults.web_acl_id, null)
+  tags                          = try(each.value.tags, var.defaults.tags, null)
+  origin                        = try(each.value.origin, var.defaults.origin, null)
+  origin_group                  = try(each.value.origin_group, var.defaults.origin_group, {})
+  viewer_certificate = try(each.value.viewer_certificate, var.defaults.viewer_certificate, {
+    cloudfront_default_certificate = true
+    minimum_protocol_version       = "TLSv1"
+  })
+  geo_restriction                      = try(each.value.geo_restriction, var.defaults.geo_restriction, {})
+  logging_config                       = try(each.value.logging_config, var.defaults.logging_config, {})
+  custom_error_response                = try(each.value.custom_error_response, var.defaults.custom_error_response, {})
+  default_cache_behavior               = try(each.value.default_cache_behavior, var.defaults.default_cache_behavior, null)
+  ordered_cache_behavior               = try(each.value.ordered_cache_behavior, var.defaults.ordered_cache_behavior, [])
+  create_monitoring_subscription       = try(each.value.create_monitoring_subscription, var.defaults.create_monitoring_subscription, false)
+  realtime_metrics_subscription_status = try(each.value.realtime_metrics_subscription_status, var.defaults.realtime_metrics_subscription_status, "Enabled")
+}

--- a/wrappers/outputs.tf
+++ b/wrappers/outputs.tf
@@ -1,0 +1,5 @@
+output "wrapper" {
+  description = "Map of outputs of a wrapper."
+  value       = module.wrapper
+  # sensitive = false  # No sensitive module output found
+}

--- a/wrappers/variables.tf
+++ b/wrappers/variables.tf
@@ -1,0 +1,11 @@
+variable "defaults" {
+  description = "Map of default values which will be used for each item."
+  type        = any
+  default     = {}
+}
+
+variable "items" {
+  description = "Maps of items to create a wrapper from. Values are passed through to the module."
+  type        = any
+  default     = {}
+}

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13.1"
+}


### PR DESCRIPTION
## Description
Support for new origin parameter "origin_access_control_id" introduced in 4.29.0 of aws provider.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
provider version >= 4.29.0

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
