### PR TITLE
fix: Update CI configuration files to use latest version

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,21 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '50 1 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-comment: >
+            I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+            If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          issue-inactive-days: '30'
+          pr-comment: >
+            I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+            If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          pr-inactive-days: '30'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v3.4.6
+      - uses: amannn/action-semantic-pull-request@v5.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,11 +17,11 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get root directories
         id: dirs
-        uses: clowdhaus/terraform-composite-actions/directories@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/directories@v1.8.0
 
   preCommitMinVersions:
     name: Min TF pre-commit
@@ -32,11 +32,11 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.3
+        uses: clowdhaus/terraform-min-max@v1.2.0
         with:
           directory: ${{ matrix.directory }}
 
@@ -62,14 +62,14 @@ jobs:
     needs: collectInputs
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.3
+        uses: clowdhaus/terraform-min-max@v1.2.0
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository_owner == 'terraform-aws-modules'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Staling issues and PR's

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.75.0
+    rev: v1.76.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,74 +1,74 @@
 output "cloudfront_distribution_id" {
   description = "The identifier for the distribution."
-  value       = element(concat(aws_cloudfront_distribution.this.*.id, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].id, "")
 }
 
 output "cloudfront_distribution_arn" {
   description = "The ARN (Amazon Resource Name) for the distribution."
-  value       = element(concat(aws_cloudfront_distribution.this.*.arn, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].arn, "")
 }
 
 output "cloudfront_distribution_caller_reference" {
   description = "Internal value used by CloudFront to allow future updates to the distribution configuration."
-  value       = element(concat(aws_cloudfront_distribution.this.*.caller_reference, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].caller_reference, "")
 }
 
 output "cloudfront_distribution_status" {
   description = "The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system."
-  value       = element(concat(aws_cloudfront_distribution.this.*.status, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].status, "")
 }
 
 output "cloudfront_distribution_trusted_signers" {
   description = "List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs"
-  value       = element(concat(aws_cloudfront_distribution.this.*.trusted_signers, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].trusted_signers, "")
 }
 
 output "cloudfront_distribution_domain_name" {
   description = "The domain name corresponding to the distribution."
-  value       = element(concat(aws_cloudfront_distribution.this.*.domain_name, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].domain_name, "")
 }
 
 output "cloudfront_distribution_last_modified_time" {
   description = "The date and time the distribution was last modified."
-  value       = element(concat(aws_cloudfront_distribution.this.*.last_modified_time, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].last_modified_time, "")
 }
 
 output "cloudfront_distribution_in_progress_validation_batches" {
   description = "The number of invalidation batches currently in progress."
-  value       = element(concat(aws_cloudfront_distribution.this.*.in_progress_validation_batches, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].in_progress_validation_batches, "")
 }
 
 output "cloudfront_distribution_etag" {
   description = "The current version of the distribution's information."
-  value       = element(concat(aws_cloudfront_distribution.this.*.etag, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].etag, "")
 }
 
 output "cloudfront_distribution_hosted_zone_id" {
   description = "The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to."
-  value       = element(concat(aws_cloudfront_distribution.this.*.hosted_zone_id, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].hosted_zone_id, "")
 }
 
 output "cloudfront_origin_access_identities" {
   description = "The origin access identities created"
-  value       = local.create_origin_access_identity ? { for k, v in aws_cloudfront_origin_access_identity.this : k => v } : {}
+  value       = { for k, v in aws_cloudfront_origin_access_identity.this : k => v if local.create_origin_access_identity }
 }
 
 output "cloudfront_origin_access_identity_ids" {
   description = "The IDS of the origin access identities created"
-  value       = local.create_origin_access_identity ? [for v in aws_cloudfront_origin_access_identity.this : v.id] : []
+  value       = [for v in aws_cloudfront_origin_access_identity.this : v.id if local.create_origin_access_identity]
 }
 
 output "cloudfront_origin_access_identity_iam_arns" {
   description = "The IAM arns of the origin access identities created"
-  value       = local.create_origin_access_identity ? [for v in aws_cloudfront_origin_access_identity.this : v.iam_arn] : []
+  value       = [for v in aws_cloudfront_origin_access_identity.this : v.iam_arn if local.create_origin_access_identity]
 }
 
 output "cloudfront_monitoring_subscription_id" {
   description = " The ID of the CloudFront monitoring subscription, which corresponds to the `distribution_id`."
-  value       = element(concat(aws_cloudfront_monitoring_subscription.this.*.id, [""]), 0)
+  value       = try(aws_cloudfront_monitoring_subscription.this[0].id, "")
 }
 
 output "cloudfront_distribution_tags" {
   description = "Tags of the distribution's"
-  value       = element(concat(aws_cloudfront_distribution.this.*.tags_all, [""]), 0)
+  value       = try(aws_cloudfront_distribution.this[0].tags_all, "")
 }


### PR DESCRIPTION
## Description

- Update GitHub action versions to use latest. This remove warnings related to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Ensure pre-commit config is aligned with latest
- Add `lock.yml` workflow to automatically lock issues and PRs after 30 days. Theres a lot "Me too" or "I have this issue, when will this get fixed" on really old/stale issues and in order to properly triage, users need to supply their configurations. This workflow is pulled from the AWS provider's repo to force users to fill out a proper issue ticket and keep chatter out of merged PRs or old issues

## Motivation and Context

- Patch warnings on CI checks to keep output clean
- Focus on new issues and PRs

## Breaking Changes

- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
