### PR TITLE
feat: Change for_each for origin

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_cloudfront_distribution" "this" {
       }
 
       dynamic "custom_origin_config" {
-        for_each = length(lookup(origin.value, "custom_origin_config", "")) == 0 ? [] : [lookup(origin.value, "custom_origin_config", "")]
+        for_each = alltrue([contains(keys(origin.value), "custom_origin_config"), origin.value.custom_origin_config != null]) ? [lookup(origin.value, "custom_origin_config", "")] : []
 
         content {
           http_port                = custom_origin_config.value.http_port


### PR DESCRIPTION
## Description
Changed `for_each`

## Motivation and Context
Current `for_each` doesn't work with terragrunt, if there are two different cloudfronts with different `origin`s set while `origin` is `any` type

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
