### PR TITLE
fix: Updated handling of one or many custom_error_response values

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -140,6 +140,11 @@ module "cloudfront" {
     ssl_support_method  = "sni-only"
   }
 
+  custom_error_response = {
+    error_code         = 404
+    response_page_path = "/errors/404.html"
+  }
+
   geo_restriction = {
     restriction_type = "whitelist"
     locations        = ["NO", "UA", "US", "GB"]

--- a/main.tf
+++ b/main.tf
@@ -246,7 +246,7 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   dynamic "custom_error_response" {
-    for_each = var.custom_error_response
+    for_each = flatten([var.custom_error_response])
 
     content {
       error_code = custom_error_response.value["error_code"]


### PR DESCRIPTION
Fixes #88 

Valid inputs:

```
  custom_error_response = {
    error_code         = 404
    response_page_path = "/errors/404.html"
  }
```
or 
```
  custom_error_response = [{
    error_code         = 404
    response_page_path = "/errors/404.html"
  }, {
    error_code         = 403
    response_page_path = "/errors/403.html"
  }
  ]
```