### PR TITLE
fix: Fix empty list of object error when custom_error_response variable is an empty list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -246,7 +246,7 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   dynamic "custom_error_response" {
-    for_each = length(flatten([var.custom_error_response])[0]) > 0 ? flatten([var.custom_error_response]) : []
+    for_each = length(var.custom_error_response) > 0 ? flatten([var.custom_error_response]) : []
 
     content {
       error_code = custom_error_response.value["error_code"]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
There is an issue when trying to pass an empty list

Running the example with `custom_error_response = []` will result to the error

```
│ Error: Invalid index
│ 
│   on ../../main.tf line 249, in resource "aws_cloudfront_distribution" "this":
│  249:     for_each = length(flatten([var.custom_error_response])[0]) > 0 ? flatten([var.custom_error_response]) : []
│     ├────────────────
│     │ var.custom_error_response is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allow a user to: 
* use an empty map
* use an empty list
* use a map for a single custom error responses
* use a list of map for multiple custom error responses

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
