### PR TITLE
chore: Updated S3 bucket policy for OAC in the complete example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -290,10 +290,8 @@ module "records" {
   ]
 }
 
-###########################
-# Origin Access Identities
-###########################
 data "aws_iam_policy_document" "s3_policy" {
+  # Origin Access Identities
   statement {
     actions   = ["s3:GetObject"]
     resources = ["${module.s3_one.s3_bucket_arn}/static/*"]
@@ -303,24 +301,17 @@ data "aws_iam_policy_document" "s3_policy" {
       identifiers = module.cloudfront.cloudfront_origin_access_identity_iam_arns
     }
   }
-}
 
-resource "aws_s3_bucket_policy" "bucket_policy" {
-  bucket = module.s3_one.s3_bucket_id
-  policy = data.aws_iam_policy_document.s3_policy.json
-}
-  
-########################
-# Origin Access Controls
-########################
-data "aws_iam_policy_document" "s3_policy" {
+  # Origin Access Controls
   statement {
     actions   = ["s3:GetObject"]
     resources = ["${module.s3_one.s3_bucket_arn}/static/*"]
+
     principals {
       type        = "Service"
       identifiers = ["cloudfront.amazonaws.com"]
     }
+
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -309,6 +309,30 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
   bucket = module.s3_one.s3_bucket_id
   policy = data.aws_iam_policy_document.s3_policy.json
 }
+  
+########################
+# Origin Access Controls
+########################
+data "aws_iam_policy_document" "s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${module.s3_one.s3_bucket_arn}/static/*"]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = [module.cloudfront.cloudfront_distribution_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = module.s3_one.s3_bucket_id
+  policy = data.aws_iam_policy_document.s3_policy.json
+}
 
 ########
 # Extra


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We recently add the OAC support with https://github.com/terraform-aws-modules/terraform-aws-cloudfront/pull/97 but we didn't give a complete example on how to use it : we need to add an IAM policy on the bucket

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I completed the example with the IAM code required.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
