### PR TITLE
fix: Wrong custom_error_response validation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -258,7 +258,7 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   dynamic "custom_error_response" {
-    for_each = length(flatten([var.custom_error_response])[0]) > 0 ? flatten([var.custom_error_response]) : []
+    for_each = length(flatten([var.custom_error_response])) > 0 ? flatten([var.custom_error_response]) : []
 
     content {
       error_code = custom_error_response.value["error_code"]


### PR DESCRIPTION
## Description
Wrong validation for empty list

## Motivation and Context
see #121 

## Breaking Changes
No

## How Has This Been Tested?
- [ x ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ x ] I have executed `pre-commit run -a` on my pull request
