### PR TITLE
fix: Fix provider version for `staging` and `continuous_deployment_policy_id` params

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ ordered_cache_behavior = [{
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.29 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.29 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.12.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.29"
+      version = ">= 5.12.0"
     }
   }
 }


### PR DESCRIPTION
AWS Terraform provider version lower than [5.12.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5120-august-10-2023) doesn't support `staging` and `continuous_deployment_policy_id` params which were added in the new version [v3.3.0](https://github.com/terraform-aws-modules/terraform-aws-cloudfront/releases/tag/v3.3.0) of this module.

## Description
Set and new min version of Terraform provider

## Motivation and Context
It fixes failing plan/applies when AWS Terraform provider version lower than 5.12.0
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
Yes, this looks like breaking change and requires a new major version of module. However, it's already broken...
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
