### PR TITLE
feat: Support multi distribution creation in the same region that serve different domains

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,89 +1,54 @@
 output "cloudfront_distribution_id" {
   description = "The identifier for the distribution."
-  value       = try(aws_cloudfront_distribution.this[0].id, "")
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.id }
 }
 
 output "cloudfront_distribution_arn" {
   description = "The ARN (Amazon Resource Name) for the distribution."
-  value       = try(aws_cloudfront_distribution.this[0].arn, "")
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.arn }
 }
 
 output "cloudfront_distribution_caller_reference" {
   description = "Internal value used by CloudFront to allow future updates to the distribution configuration."
-  value       = try(aws_cloudfront_distribution.this[0].caller_reference, "")
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.caller_reference }
 }
 
 output "cloudfront_distribution_status" {
-  description = "The current status of the distribution. Deployed if the distribution's information is fully propagated throughout the Amazon CloudFront system."
-  value       = try(aws_cloudfront_distribution.this[0].status, "")
+  description = "The current status of the distribution."
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.status }
 }
 
 output "cloudfront_distribution_trusted_signers" {
   description = "List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs"
-  value       = try(aws_cloudfront_distribution.this[0].trusted_signers, "")
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.trusted_signers }
 }
 
 output "cloudfront_distribution_domain_name" {
   description = "The domain name corresponding to the distribution."
-  value       = try(aws_cloudfront_distribution.this[0].domain_name, "")
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.domain_name }
 }
 
 output "cloudfront_distribution_last_modified_time" {
   description = "The date and time the distribution was last modified."
-  value       = try(aws_cloudfront_distribution.this[0].last_modified_time, "")
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.last_modified_time }
 }
 
 output "cloudfront_distribution_in_progress_validation_batches" {
   description = "The number of invalidation batches currently in progress."
-  value       = try(aws_cloudfront_distribution.this[0].in_progress_validation_batches, "")
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.in_progress_validation_batches }
 }
 
 output "cloudfront_distribution_etag" {
   description = "The current version of the distribution's information."
-  value       = try(aws_cloudfront_distribution.this[0].etag, "")
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.etag }
 }
 
 output "cloudfront_distribution_hosted_zone_id" {
   description = "The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to."
-  value       = try(aws_cloudfront_distribution.this[0].hosted_zone_id, "")
-}
-
-output "cloudfront_origin_access_identities" {
-  description = "The origin access identities created"
-  value       = { for k, v in aws_cloudfront_origin_access_identity.this : k => v if local.create_origin_access_identity }
-}
-
-output "cloudfront_origin_access_identity_ids" {
-  description = "The IDS of the origin access identities created"
-  value       = [for v in aws_cloudfront_origin_access_identity.this : v.id if local.create_origin_access_identity]
-}
-
-output "cloudfront_origin_access_identity_iam_arns" {
-  description = "The IAM arns of the origin access identities created"
-  value       = [for v in aws_cloudfront_origin_access_identity.this : v.iam_arn if local.create_origin_access_identity]
-}
-
-output "cloudfront_monitoring_subscription_id" {
-  description = " The ID of the CloudFront monitoring subscription, which corresponds to the `distribution_id`."
-  value       = try(aws_cloudfront_monitoring_subscription.this[0].id, "")
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.hosted_zone_id }
 }
 
 output "cloudfront_distribution_tags" {
-  description = "Tags of the distribution's"
-  value       = try(aws_cloudfront_distribution.this[0].tags_all, "")
-}
-
-output "cloudfront_origin_access_controls" {
-  description = "The origin access controls created"
-  value       = local.create_origin_access_control ? { for k, v in aws_cloudfront_origin_access_control.this : k => v } : {}
-}
-
-output "cloudfront_origin_access_controls_ids" {
-  description = "The IDS of the origin access identities created"
-  value       = local.create_origin_access_control ? [for v in aws_cloudfront_origin_access_control.this : v.id] : []
-}
-
-output "cloudfront_vpc_origin_ids" {
-  description = "The IDS of the VPC origin created"
-  value       = local.create_vpc_origin ? [for v in aws_cloudfront_vpc_origin.this : v.id] : []
+  description = "Tags of the distributions"
+  value       = { for k, v in aws_cloudfront_distribution.this : k => v.tags_all }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,161 +1,153 @@
-variable "create_distribution" {
-  description = "Controls if CloudFront distribution should be created"
-  type        = bool
-  default     = true
-}
-
-variable "create_origin_access_identity" {
-  description = "Controls if CloudFront origin access identity should be created"
-  type        = bool
-  default     = false
-}
-
-variable "origin_access_identities" {
-  description = "Map of CloudFront origin access identities (value as a comment)"
-  type        = map(string)
-  default     = {}
-}
-
-variable "create_origin_access_control" {
-  description = "Controls if CloudFront origin access control should be created"
-  type        = bool
-  default     = false
-}
-
-variable "origin_access_control" {
-  description = "Map of CloudFront origin access control"
+variable "distributions" {
   type = map(object({
-    description      = string
-    origin_type      = string
-    signing_behavior = string
-    signing_protocol = string
+    aliases                         = optional(list(string), [])
+    comment                         = optional(string, null)
+    continuous_deployment_policy_id = optional(string, null)
+    default_root_object             = optional(string, null)
+    enabled                         = optional(bool, true)
+    http_version                    = optional(string, "http2")
+    is_ipv6_enabled                 = optional(bool, null)
+    price_class                     = optional(string, null)
+    retain_on_delete                = optional(bool, false)
+    staging                         = optional(bool, false)
+    wait_for_deployment             = optional(bool, true)
+    web_acl_id                      = optional(string, null)
+    tags                            = map(string)
+
+    logging_config = optional(map(string), {})
+
+    origin = map(object({
+      domain_name              = string
+      origin_id                = string
+      origin_path              = optional(string, "")
+      connection_attempts      = optional(number, 3)
+      connection_timeout       = optional(number, 10)
+      origin_access_control_id = optional(string, null)
+
+      custom_origin_config = object({
+        http_port                = number
+        https_port               = number
+        origin_protocol_policy   = string
+        origin_ssl_protocols     = list(string)
+        origin_keepalive_timeout = optional(number, 60)
+        origin_read_timeout      = optional(number, 30)
+      })
+
+      custom_header = optional(list(object({
+        name  = string
+        value = string
+      })), [])
+
+      origin_shield = optional(object({
+        enabled              = optional(bool, false)
+        origin_shield_region = optional(string, "us-east-1")
+      }), {})
+    }))
+
+    origin_group = optional(map(object({
+      origin_id                  = string
+      failover_status_codes      = optional(list(number), [])
+      primary_member_origin_id   = optional(string, null)
+      secondary_member_origin_id = optional(string, null)
+    })), {})
+
+    default_cache_behavior = object({
+      target_origin_id           = string
+      viewer_protocol_policy     = optional(string, null)
+      allowed_methods            = optional(list(string), ["GET", "HEAD", "OPTIONS"])
+      cached_methods             = optional(list(string), ["GET", "HEAD"])
+      compress                   = optional(bool, null)
+      field_level_encryption_id  = optional(string, null)
+      smooth_streaming           = optional(bool, null)
+      trusted_signers            = optional(list(string), [])
+      trusted_key_groups         = optional(list(string), [])
+      cache_policy_id            = optional(string, null)
+      origin_request_policy_id   = optional(string, null)
+      response_headers_policy_id = optional(string, null)
+
+      min_ttl     = optional(number, null)
+      default_ttl = optional(number, null)
+      max_ttl     = optional(number, null)
+
+      use_forwarded_values    = optional(bool, true)
+      query_string            = optional(bool, true)
+      query_string_cache_keys = optional(list(string), [])
+      headers                 = optional(list(string), [])
+
+      cookies_forward           = optional(string, "none")
+      cookies_whitelisted_names = optional(list(string), [])
+
+      lambda_function_association = optional(list(object({
+        event_type   = optional(string, null)
+        lambda_arn   = optional(string, null)
+        include_body = optional(bool, null)
+      })), [])
+
+      function_association = optional(list(object({
+        event_type   = optional(string, null)
+        function_arn = optional(string, null)
+      })), [])
+    })
+
+    ordered_cache_behavior = optional(list(object({
+      path_pattern               = optional(string, null)
+      target_origin_id           = optional(string, null)
+      viewer_protocol_policy     = string
+      allowed_methods            = optional(list(string), ["GET", "HEAD"])
+      cached_methods             = optional(list(string), ["GET", "HEAD"])
+      compress                   = optional(bool, null)
+      field_level_encryption_id  = optional(string, null)
+      smooth_streaming           = optional(bool, null)
+      trusted_signers            = optional(list(string), [])
+      trusted_key_groups         = optional(list(string), [])
+      cache_policy_id            = optional(string, null)
+      origin_request_policy_id   = optional(string, null)
+      response_headers_policy_id = optional(string, null)
+
+      min_ttl     = optional(number, null)
+      default_ttl = optional(number, null)
+      max_ttl     = optional(number, null)
+
+      use_forwarded_values      = optional(bool, true)
+      query_string              = optional(bool, false)
+      query_string_cache_keys   = optional(list(string), [])
+      headers                   = optional(list(string), [])
+      cookies_forward           = optional(string, "none")
+      cookies_whitelisted_names = optional(list(string), [])
+
+      lambda_function_association = optional(list(object({
+        event_type   = optional(string, null)
+        lambda_arn   = optional(string, null)
+        include_body = optional(bool, null)
+      })), [])
+
+      function_association = optional(list(object({
+        event_type   = optional(string, null)
+        function_arn = optional(string, null)
+      })), [])
+    })), [])
+
+    viewer_certificate = object({
+      acm_certificate_arn            = string
+      cloudfront_default_certificate = optional(bool, false)
+      iam_certificate_id             = optional(string, null)
+      minimum_protocol_version       = string
+      ssl_support_method             = string
+    })
+
+    custom_error_response = optional(list(object({
+      error_code            = optional(string, null)
+      response_code         = optional(number, null)
+      response_page_path    = optional(string, null)
+      error_caching_min_ttl = optional(number, null)
+    })), [])
+
+    geo_restriction = object({
+      restriction_type = string
+      locations        = list(string)
+    })
   }))
-
-  default = {
-    s3 = {
-      description      = "",
-      origin_type      = "s3",
-      signing_behavior = "always",
-      signing_protocol = "sigv4"
-    }
-  }
-}
-
-variable "aliases" {
-  description = "Extra CNAMEs (alternate domain names), if any, for this distribution."
-  type        = list(string)
-  default     = null
-}
-
-variable "comment" {
-  description = "Any comments you want to include about the distribution."
-  type        = string
-  default     = null
-}
-
-variable "continuous_deployment_policy_id" {
-  description = "Identifier of a continuous deployment policy. This argument should only be set on a production distribution."
-  type        = string
-  default     = null
-}
-
-variable "default_root_object" {
-  description = "The object that you want CloudFront to return (for example, index.html) when an end user requests the root URL."
-  type        = string
-  default     = null
-}
-
-variable "enabled" {
-  description = "Whether the distribution is enabled to accept end user requests for content."
-  type        = bool
-  default     = true
-}
-
-variable "http_version" {
-  description = "The maximum HTTP version to support on the distribution. Allowed values are http1.1, http2, http2and3, and http3. The default is http2."
-  type        = string
-  default     = "http2"
-}
-
-variable "is_ipv6_enabled" {
-  description = "Whether the IPv6 is enabled for the distribution."
-  type        = bool
-  default     = null
-}
-
-variable "price_class" {
-  description = "The price class for this distribution. One of PriceClass_All, PriceClass_200, PriceClass_100"
-  type        = string
-  default     = null
-}
-
-variable "retain_on_delete" {
-  description = "Disables the distribution instead of deleting it when destroying the resource through Terraform. If this is set, the distribution needs to be deleted manually afterwards."
-  type        = bool
-  default     = false
-}
-
-variable "wait_for_deployment" {
-  description = "If enabled, the resource will wait for the distribution status to change from InProgress to Deployed. Setting this to false will skip the process."
-  type        = bool
-  default     = true
-}
-
-variable "web_acl_id" {
-  description = "If you're using AWS WAF to filter CloudFront requests, the Id of the AWS WAF web ACL that is associated with the distribution. The WAF Web ACL must exist in the WAF Global (CloudFront) region and the credentials configuring this argument must have waf:GetWebACL permissions assigned. If using WAFv2, provide the ARN of the web ACL."
-  type        = string
-  default     = null
-}
-
-variable "staging" {
-  description = "Whether the distribution is a staging distribution."
-  type        = bool
-  default     = false
-}
-
-variable "tags" {
-  description = "A map of tags to assign to the resource."
-  type        = map(string)
-  default     = null
-}
-
-variable "origin" {
-  description = "One or more origins for this distribution (multiples allowed)."
-  type        = any
-  default     = null
-}
-
-variable "origin_group" {
-  description = "One or more origin_group for this distribution (multiples allowed)."
-  type        = any
-  default     = {}
-}
-
-variable "viewer_certificate" {
-  description = "The SSL configuration for this distribution"
-  type        = any
-  default = {
-    cloudfront_default_certificate = true
-    minimum_protocol_version       = "TLSv1"
-  }
-}
-
-variable "geo_restriction" {
-  description = "The restriction configuration for this distribution (geo_restrictions)"
-  type        = any
-  default     = {}
-}
-
-variable "logging_config" {
-  description = "The logging configuration that controls how logs are written to your distribution (maximum one)."
-  type        = any
-  default     = {}
-}
-
-variable "custom_error_response" {
-  description = "One or more custom error response elements"
-  type        = any
-  default     = {}
+  description = "Map of CloudFront distributions"
 }
 
 variable "default_cache_behavior" {
@@ -168,38 +160,4 @@ variable "ordered_cache_behavior" {
   description = "An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0."
   type        = any
   default     = []
-}
-
-variable "create_monitoring_subscription" {
-  description = "If enabled, the resource for monitoring subscription will created."
-  type        = bool
-  default     = false
-}
-
-variable "realtime_metrics_subscription_status" {
-  description = "A flag that indicates whether additional CloudWatch metrics are enabled for a given CloudFront distribution. Valid values are `Enabled` and `Disabled`."
-  type        = string
-  default     = "Enabled"
-}
-
-variable "create_vpc_origin" {
-  description = "If enabled, the resource for VPC origin will be created."
-  type        = bool
-  default     = false
-}
-
-variable "vpc_origin" {
-  description = "Map of CloudFront VPC origin"
-  type = map(object({
-    name                   = string
-    arn                    = string
-    http_port              = number
-    https_port             = number
-    origin_protocol_policy = string
-    origin_ssl_protocols = object({
-      items    = list(string)
-      quantity = number
-    })
-  }))
-  default = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.83"
+      version = ">= 5.12.0"
     }
   }
 }


### PR DESCRIPTION
## Description
The change is to support creation of multiple cloudfront distributions in the same region while sharing common config like cache behaviors and origin configurations, but serve different domains that require separate SSL/TLS certificates.

## Motivation and Context
 Current module doesn't support multiple certificates on a single distribution, so a separate distribution must be created for each domain that needs its own certificate.