### PR TITLE
Updating the wrapper output as sensitive to prevent exposure of secre…

### DIFF
--- a/wrappers/outputs.tf
+++ b/wrappers/outputs.tf
@@ -1,5 +1,5 @@
 output "wrapper" {
   description = "Map of outputs of a wrapper."
   value       = module.wrapper
-  # sensitive = false # No sensitive module output found
+  sensitive   = true # Set to true to hide the sensitive output in the console
 }


### PR DESCRIPTION
…t values in terragrunt apply logs

## Description
This PR updates the output "wrapper" block in the cloudfront support module wrapper to set the sensitive flag to "true" value.

Terragrunt apply logs for cloudfront distributions expose a secret value being inserted for custom origin request header when passed through this wrapper output. 

By marking the wrapper output as sensitive we ensure consistent redaction of secrets across all stages of terragrunt output, avoiding any accidental exposure of sensitive vault derived values in logs.

## Motivation and Context
This change is required to prevent exposure of sensitive vault derived values in terragrunt logs

## Breaking Changes
NA