### PR TITLE
fix: Only create origin_shield block when explicitly enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ resource "aws_cloudfront_distribution" "this" {
       }
 
       dynamic "origin_shield" {
-        for_each = length(keys(lookup(origin.value, "origin_shield", {}))) == 0 ? [] : [lookup(origin.value, "origin_shield", {})]
+        for_each = lookup(lookup(origin.value, "origin_shield", {}), "enabled", false) ? [lookup(origin.value, "origin_shield", {})] : []
 
         content {
           enabled              = origin_shield.value.enabled


### PR DESCRIPTION
## Description
Previously the dynamic block was created whenever origin_shield config existed, even with enabled = false. Now only creates the block when enabled = true, preventing unnecessary resource updates.

## Motivation and Context
Prevents unnecessary removal and recreation of origin resources even when no changes have been made, when 'origin_shield' is defined as enabled = false.

## Issue
Previously observed in - #142