### PR TITLE
fix: Avoid adding a `null` value to `concat()` function for cache behaviors local variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -535,7 +535,7 @@ resource "aws_cloudfront_monitoring_subscription" "this" {
 ################################################################################
 
 locals {
-  cache_behaviors = concat([var.default_cache_behavior], var.ordered_cache_behavior)
+  cache_behaviors = var.ordered_cache_behavior != null ? concat([var.default_cache_behavior], var.ordered_cache_behavior) : [var.default_cache_behavior]
 }
 
 data "aws_cloudfront_cache_policy" "this" {


### PR DESCRIPTION
## Description
- Avoid adding a `null` value to `concat()` function for cache behaviors local variable

## Motivation and Context
- Resolves #178

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
