### PR TITLE
fix: Correct v2_logging example configuration

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -46,10 +46,14 @@ module "cloudfront" {
 
   # v2 Logging - logs to S3 with CloudWatch Log Delivery
   # Note: This supersedes the legacy logging_config which used S3 ACLs
+  enable_v2_logging = true
   v2_logging = {
-    name            = "example-v2-logs"
-    destination_arn = "${module.log_bucket.s3_bucket_arn}/cloudfront"
-    output_format   = "parquet"
+    name = "example-v2-logs"
+    delivery_destination_configuration = {
+      destination_resource_arn = "${module.log_bucket.s3_bucket_arn}/cloudfront"
+    }
+    delivery_destination_type = "S3"
+    output_format             = "parquet"
 
     s3_delivery_configuration = {
       enable_hive_compatible_path = true


### PR DESCRIPTION
### **Description**                                                                                                                                                     
                                                                                                                                                                  
  Fixed incorrect v2_logging configuration in examples/complete/main.tf:                                                                                          
  - Replaced non-existent destination_arn attribute with correct delivery_destination_configuration.destination_resource_arn                                      
  - Added required delivery_destination_type = "S3" field                                                                                                         
  - Added missing enable_v2_logging = true so the v2 logging resources are actually created                                                                       
                                                                                                                                                                  
###   **Motivation and Context**                                                                                                                                          
                                                                                                                                                                  
  The complete example for v2_logging used attribute names that don't match the variable type definition in variables.tf, making the example non-functional.      
                                                                                                                                                                  
  Closes #196                                                                                                                                                     
                                                                                                                                                                
###   **Breaking Changes**                                                                                                                                                
   
  None.                                                                                     
                                                                                                                                                                
###   **How Has This Been Tested?**                                                                                                                                       
                                                                                                                                                                
  - [x] I have updated at least one of the examples/* to show and validate my change                                                                              
  - [x] I have tested and validated these changes using one or more of the provided examples/* projects                                                           
  - [x] I have executed pre-commit run -a on my pull request                                                                                                        
                                                                                                                                                                  
  Validated with terraform init -backend=false, terraform validate, and terraform fmt -check -recursive on examples/complete/.   