### PR TITLE
fix: Logging v2 CloudWatch resources only support `us-east-1`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -601,6 +601,8 @@ resource "aws_cloudwatch_log_delivery_source" "this" {
   name         = "cloudfront-${aws_cloudfront_distribution.this[0].id}"
   resource_arn = aws_cloudfront_distribution.this[0].arn
 
+  region = "us-east-1"
+
   tags = var.tags
 }
 
@@ -618,6 +620,8 @@ resource "aws_cloudwatch_log_delivery_destination" "this" {
   delivery_destination_type = var.v2_logging.delivery_destination_type
   name                      = var.v2_logging.name
   output_format             = var.v2_logging.output_format
+
+  region = "us-east-1"
 
   tags = var.tags
 }
@@ -638,6 +642,8 @@ resource "aws_cloudwatch_log_delivery" "this" {
       suffix_path                 = s3_delivery_configuration.value.suffix_path
     }
   }
+
+  region = "us-east-1"
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -601,6 +601,8 @@ resource "aws_cloudwatch_log_delivery_source" "this" {
   name         = "cloudfront-${aws_cloudfront_distribution.this[0].id}"
   resource_arn = aws_cloudfront_distribution.this[0].arn
 
+  # CloudFront standard logging API calls must always target us-east-1
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html#enable-access-logging-api
   region = "us-east-1"
 
   tags = var.tags
@@ -621,6 +623,8 @@ resource "aws_cloudwatch_log_delivery_destination" "this" {
   name                      = var.v2_logging.name
   output_format             = var.v2_logging.output_format
 
+  # CloudFront standard logging API calls must always target us-east-1
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html#enable-access-logging-api
   region = "us-east-1"
 
   tags = var.tags
@@ -643,6 +647,8 @@ resource "aws_cloudwatch_log_delivery" "this" {
     }
   }
 
+  # CloudFront standard logging API calls must always target us-east-1
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html#enable-access-logging-api
   region = "us-east-1"
 
   tags = var.tags


### PR DESCRIPTION
## Description

Fixes #197

When `enable_v2_logging` is enabled, the three CloudWatch log delivery resources (`aws_cloudwatch_log_delivery_source`, `aws_cloudwatch_log_delivery_destination`, `aws_cloudwatch_log_delivery`) were created using the default AWS provider region. CloudFront standard logging API calls are only supported in `us-east-1`, so any deployment with a non-`us-east-1` default provider (e.g. `eu-west-1`) would fail with:

```
ValidationException: PutDeliverySource action is not supported for this LogType in region eu-west-1
```

This is documented in the [CloudFront standard logging docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html#enable-access-logging-api):

> When calling the CloudWatch API to enable standard logging, you must specify the US East (N. Virginia) Region (`us-east-1`), even if you want to enable cross Region delivery to another destination.

## Changes

Added `region = "us-east-1"` to all three CloudWatch log delivery resources.